### PR TITLE
(GH-2) Properly parse comments in multi-line arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This project makes use of mocha and expect.js.  The tests are located in the `/t
 
 To run tests use;
 
-`npm run tests`
+`npm run test`
 
 ### Converting to other formats
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,15 @@
+clone_depth: 10
+init:
+- SET
+
+install:
+  - npm install
+
+test_script:
+  - node --version
+  - npm --version
+  - npm run test
+  - npm run convert error-on-change
+
+# Don't actually build.
+build: off

--- a/generated-syntaxes/puppet.tmLanguage.atom.cson
+++ b/generated-syntaxes/puppet.tmLanguage.atom.cson
@@ -411,6 +411,9 @@
       {
         'include': '#parameter-default-types'
       }
+      {
+        'include': '#line_comment'
+      }
     ]
   'hash':
     'begin': '\\{'

--- a/generated-syntaxes/puppet.tmLanguage.cson
+++ b/generated-syntaxes/puppet.tmLanguage.cson
@@ -411,6 +411,9 @@ repository:
       {
         include: "#parameter-default-types"
       }
+      {
+        include: "#line_comment"
+      }
     ]
   hash:
     begin: "\\{"

--- a/generated-syntaxes/puppet.tmLanguage.json
+++ b/generated-syntaxes/puppet.tmLanguage.json
@@ -490,6 +490,9 @@
       "patterns": [
         {
           "include": "#parameter-default-types"
+        },
+        {
+          "include": "#line_comment"
         }
       ]
     },

--- a/generated-syntaxes/puppet.tmLanguage.yaml
+++ b/generated-syntaxes/puppet.tmLanguage.yaml
@@ -264,6 +264,7 @@ repository:
     name: meta.array.puppet
     patterns:
       - include: '#parameter-default-types'
+      - include: '#line_comment'
   hash:
     begin: '\{'
     beginCaptures:

--- a/syntaxes/puppet.tmLanguage
+++ b/syntaxes/puppet.tmLanguage
@@ -765,6 +765,10 @@
           <key>include</key>
           <string>#parameter-default-types</string>
         </dict>
+        <dict>
+          <key>include</key>
+          <string>#line_comment</string>
+        </dict>
       </array>
     </dict>
     <key>hash</key>

--- a/tests/syntaxes/puppet.tmLanguage.js
+++ b/tests/syntaxes/puppet.tmLanguage.js
@@ -118,6 +118,14 @@ describe('puppet.tmLanguage', function() {
     };
   });
 
+  describe('arrays', function() {
+    it("tokenizes line comments", function() {
+      var tokens = getLineTokens(grammar, "package{ [\n'element1', # This is a comment\n'element2']:\nensure => present\n}")
+
+      expect(tokens[7]).to.eql({value: '#', scopes: ['source.puppet', 'meta.array.puppet', 'comment.line.number-sign.puppet', 'punctuation.definition.comment.puppet']});
+      expect(tokens[8]).to.eql({value: ' This is a comment\n', scopes: ['source.puppet', 'meta.array.puppet', 'comment.line.number-sign.puppet']});
+    });
+  });
 
   describe('puppet tasks and plans', function() {
     it("tokenizes plan keyword", function() {


### PR DESCRIPTION
Previously you could not span an array over multiple lines with interspersed
comments. This was due to the array matcher not expecting line comments. This
commit updates the parser to look for comments and adds tests for this scenario.