### PR TITLE
(GH-6) Correctly tokenize chaining arrows

### DIFF
--- a/generated-syntaxes/puppet.tmLanguage.atom.cson
+++ b/generated-syntaxes/puppet.tmLanguage.atom.cson
@@ -18,7 +18,7 @@
     'name': 'comment.block.puppet'
   }
   {
-    'begin': '^\\s*(node|class)\\s+((?:[-_A-Za-z0-9"\'.]+::)*[-_A-Za-z0-9"\'.]+)\\s*'
+    'begin': '\\b(node|class)\\s+((?:[-_A-Za-z0-9"\'.]+::)*[-_A-Za-z0-9"\'.]+)\\s*'
     'captures':
       '1':
         'name': 'storage.type.puppet'
@@ -227,6 +227,14 @@
   {
     'match': '=>'
     'name': 'punctuation.separator.key-value.puppet'
+  }
+  {
+    'match': '->'
+    'name': 'keyword.control.orderarrow.puppet'
+  }
+  {
+    'match': '~>'
+    'name': 'keyword.control.notifyarrow.puppet'
   }
 ]
 'repository': 

--- a/generated-syntaxes/puppet.tmLanguage.cson
+++ b/generated-syntaxes/puppet.tmLanguage.cson
@@ -18,7 +18,7 @@ patterns: [
     name: "comment.block.puppet"
   }
   {
-    begin: "^\\s*(node|class)\\s+((?:[-_A-Za-z0-9\"\\'.]+::)*[-_A-Za-z0-9\"\\'.]+)\\s*"
+    begin: "\\b(node|class)\\s+((?:[-_A-Za-z0-9\"\\'.]+::)*[-_A-Za-z0-9\"\\'.]+)\\s*"
     captures:
       "1":
         name: "storage.type.puppet"
@@ -227,6 +227,14 @@ patterns: [
   {
     match: "=>"
     name: "punctuation.separator.key-value.puppet"
+  }
+  {
+    match: "->"
+    name: "keyword.control.orderarrow.puppet"
+  }
+  {
+    match: "~>"
+    name: "keyword.control.notifyarrow.puppet"
   }
 ]
 repository:

--- a/generated-syntaxes/puppet.tmLanguage.json
+++ b/generated-syntaxes/puppet.tmLanguage.json
@@ -19,7 +19,7 @@
       "name": "comment.block.puppet"
     },
     {
-      "begin": "^\\s*(node|class)\\s+((?:[-_A-Za-z0-9\"\\'.]+::)*[-_A-Za-z0-9\"\\'.]+)\\s*",
+      "begin": "\\b(node|class)\\s+((?:[-_A-Za-z0-9\"\\'.]+::)*[-_A-Za-z0-9\"\\'.]+)\\s*",
       "captures": {
         "1": {
           "name": "storage.type.puppet"
@@ -271,6 +271,14 @@
     {
       "match": "=>",
       "name": "punctuation.separator.key-value.puppet"
+    },
+    {
+      "match": "->",
+      "name": "keyword.control.orderarrow.puppet"
+    },
+    {
+      "match": "~>",
+      "name": "keyword.control.notifyarrow.puppet"
     }
   ],
   "repository": {

--- a/generated-syntaxes/puppet.tmLanguage.yaml
+++ b/generated-syntaxes/puppet.tmLanguage.yaml
@@ -10,7 +10,7 @@ patterns:
   - begin: ^\s*/\*
     end: \*/
     name: comment.block.puppet
-  - begin: '^\s*(node|class)\s+((?:[-_A-Za-z0-9"\''.]+::)*[-_A-Za-z0-9"\''.]+)\s*'
+  - begin: '\b(node|class)\s+((?:[-_A-Za-z0-9"\''.]+::)*[-_A-Za-z0-9"\''.]+)\s*'
     captures:
       '1':
         name: storage.type.puppet
@@ -150,6 +150,10 @@ patterns:
     name: support.function.puppet
   - match: =>
     name: punctuation.separator.key-value.puppet
+  - match: '->'
+    name: keyword.control.orderarrow.puppet
+  - match: ~>
+    name: keyword.control.notifyarrow.puppet
 repository:
   constants:
     patterns:

--- a/syntaxes/puppet.tmLanguage
+++ b/syntaxes/puppet.tmLanguage
@@ -34,7 +34,7 @@
     </dict>
     <dict>
       <key>begin</key>
-      <string>^\s*(node|class)\s+((?:[-_A-Za-z0-9"\'.]+::)*[-_A-Za-z0-9"\'.]+)\s*</string>
+      <string>\b(node|class)\s+((?:[-_A-Za-z0-9"\'.]+::)*[-_A-Za-z0-9"\'.]+)\s*</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -430,6 +430,18 @@
       <string>=></string>
       <key>name</key>
       <string>punctuation.separator.key-value.puppet</string>
+    </dict>
+    <dict>
+      <key>match</key>
+      <string>-></string>
+      <key>name</key>
+      <string>keyword.control.orderarrow.puppet</string>
+    </dict>
+    <dict>
+      <key>match</key>
+      <string>~></string>
+      <key>name</key>
+      <string>keyword.control.notifyarrow.puppet</string>
     </dict>
   </array>
   <key>repository</key>


### PR DESCRIPTION
Previously chaining arrows were not accounted for, which broke tokenization
after them.  This commit adds the correct patterns for the arrows.  The class
regex was changed as using `^` is incorrect, it should really be looking for
word boundaries.  This commit also adds tests for the chaining arrows.

---

Reminder

- [x] Added Tests

- [x] Ran `npm run convert` and committed the changes too
