### PR TITLE
(GH-8) Add regex support

### DIFF
--- a/generated-syntaxes/puppet.tmLanguage.atom.cson
+++ b/generated-syntaxes/puppet.tmLanguage.atom.cson
@@ -236,6 +236,9 @@
     'match': '~>'
     'name': 'keyword.control.notifyarrow.puppet'
   }
+  {
+    'include': '#regex-literal'
+  }
 ]
 'repository': 
   'constants':
@@ -524,3 +527,7 @@
         'name': 'storage.type.puppet'
       }
     ]
+  'regex-literal':
+    'match': '(\\/)(.+)(?:\\/)'
+    'name': 'string.regexp.literal.puppet'
+    'comment': 'Puppet Regular expression literal without interpolation'

--- a/generated-syntaxes/puppet.tmLanguage.cson
+++ b/generated-syntaxes/puppet.tmLanguage.cson
@@ -236,6 +236,9 @@ patterns: [
     match: "~>"
     name: "keyword.control.notifyarrow.puppet"
   }
+  {
+    include: "#regex-literal"
+  }
 ]
 repository:
   constants:
@@ -524,3 +527,7 @@ repository:
         name: "storage.type.puppet"
       }
     ]
+  "regex-literal":
+    match: "(\\/)(.+)(?:\\/)"
+    name: "string.regexp.literal.puppet"
+    comment: "Puppet Regular expression literal without interpolation"

--- a/generated-syntaxes/puppet.tmLanguage.json
+++ b/generated-syntaxes/puppet.tmLanguage.json
@@ -279,6 +279,9 @@
     {
       "match": "~>",
       "name": "keyword.control.notifyarrow.puppet"
+    },
+    {
+      "include": "#regex-literal"
     }
   ],
   "repository": {
@@ -624,6 +627,11 @@
           "name": "storage.type.puppet"
         }
       ]
+    },
+    "regex-literal": {
+      "match": "(\\/)(.+)(?:\\/)",
+      "name": "string.regexp.literal.puppet",
+      "comment": "Puppet Regular expression literal without interpolation"
     }
   }
 }

--- a/generated-syntaxes/puppet.tmLanguage.yaml
+++ b/generated-syntaxes/puppet.tmLanguage.yaml
@@ -154,6 +154,7 @@ patterns:
     name: keyword.control.orderarrow.puppet
   - match: ~>
     name: keyword.control.notifyarrow.puppet
+  - include: '#regex-literal'
 repository:
   constants:
     patterns:
@@ -337,4 +338,8 @@ repository:
       - comment: Puppet Data type
         match: '(?<![a-zA-Z\$])([A-Z][a-zA-Z0-9]*)(?![a-zA-Z0-9])'
         name: storage.type.puppet
+  regex-literal:
+    match: '(\/)(.+)(?:\/)'
+    name: string.regexp.literal.puppet
+    comment: Puppet Regular expression literal without interpolation
 

--- a/syntaxes/puppet.tmLanguage
+++ b/syntaxes/puppet.tmLanguage
@@ -443,6 +443,10 @@
       <key>name</key>
       <string>keyword.control.notifyarrow.puppet</string>
     </dict>
+    <dict>
+      <key>include</key>
+      <string>#regex-literal</string>
+    </dict>
   </array>
   <key>repository</key>
   <dict>
@@ -976,6 +980,15 @@
           <string>storage.type.puppet</string>
         </dict>
       </array>
+    </dict>
+    <key>regex-literal</key>
+    <dict>
+      <key>match</key>
+      <string>(\/)(.+)(?:\/)</string>
+      <key>name</key>
+      <string>string.regexp.literal.puppet</string>
+      <key>comment</key>
+      <string>Puppet Regular expression literal without interpolation</string>
     </dict>
   </dict>
 </dict>

--- a/tests/syntaxes/puppet.tmLanguage.js
+++ b/tests/syntaxes/puppet.tmLanguage.js
@@ -346,5 +346,26 @@ describe('puppet.tmLanguage', function() {
         });
       });
     };
- });
+  });
+
+  describe('regular expressions', function() {
+    var contexts = {
+      'in basic variable assignment': { 'manifest': "$foo = /abc123/", 'expectedTokenIndex': 3, 'expectedRegExText': 'abc123' },
+      'in basic if statement': { 'manifest': "if 'foo' =~ /walrus/ {\n  $walrus = true\n}", 'expectedTokenIndex': 6, 'expectedRegExText': 'walrus' },
+      'with special characters': { 'manifest': "$foo = /ab\\c#12\\/3/\n$bar = 'wee'", 'expectedTokenIndex': 3, 'expectedRegExText': 'ab\\c#12\\/3' },
+    }
+
+    for(var contextName in contexts) {
+      context(contextName, function() {
+        var tokenIndex = contexts[contextName]['expectedTokenIndex']
+        var expectedRegExText = contexts[contextName]['expectedRegExText']
+        var manifest = contexts[contextName]['manifest']
+
+        it("tokenizes regular expression " + contextName, function() {
+          var tokens = getLineTokens(grammar, manifest);
+          expect(tokens[tokenIndex]).to.eql({value: '/' + expectedRegExText + '/', scopes: ['source.puppet', 'string.regexp.literal.puppet']});
+        });
+      });
+    };
+  });
 });


### PR DESCRIPTION
Previously the syntax highlighter didn't understand regex literals which caused
errors such as hashes `#` in regexes being treated as a comment character.  This
commit adds the syntax information in order to detection Puppet regular
expressions.

https://puppet.com/docs/puppet/latest/lang_data_regexp.html

Fixes #8 
---

Reminder

- [x] Added Tests

- [x] Ran `npm run convert` and committed the changes too
