### PR TITLE
(GH-16) Fix variable highlighting

### DIFF
--- a/generated-syntaxes/puppet.tmLanguage.atom.cson
+++ b/generated-syntaxes/puppet.tmLanguage.atom.cson
@@ -490,20 +490,18 @@
   'variable':
     'patterns': [
       {
+        'match': '(\\$)_[a-zA-Z0-9_]*'
+        'name': 'variable.other.readwrite.global.puppet'
         'captures':
           '1':
             'name': 'punctuation.definition.variable.puppet'
-        'match': '(\\$)((::)?[a-z]\\w*)*((::)?[a-z_]\\w*)\\b'
-        'name': 'variable.other.readwrite.global.puppet'
       }
       {
+        'match': '(\\$)(([a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)*)'
+        'name': 'variable.other.readwrite.global.puppet'
         'captures':
           '1':
             'name': 'punctuation.definition.variable.puppet'
-          '2':
-            'name': 'punctuation.definition.variable.puppet'
-        'match': '(\\$\\{)(?:[a-zA-Zx7f-xff\\$]|::)(?:[a-zA-Z0-9_x7f-xff\\$]|::)*(\\})'
-        'name': 'variable.other.readwrite.global.puppet'
       }
     ]
   'function_call':

--- a/generated-syntaxes/puppet.tmLanguage.atom.cson
+++ b/generated-syntaxes/puppet.tmLanguage.atom.cson
@@ -257,13 +257,71 @@
     'endCaptures':
       '0':
         'name': 'punctuation.definition.string.end.puppet'
-    'name': 'string.quoted.double.puppet'
+    'name': 'string.quoted.double.interpolated.puppet'
     'patterns': [
       {
         'include': '#escaped_char'
       }
       {
-        'include': '#variable'
+        'include': '#interpolated_puppet'
+      }
+    ]
+  'interpolated_puppet':
+    'patterns': [
+      {
+        'begin': '(\\${)(_[a-zA-Z0-9_]*)'
+        'beginCaptures':
+          '1':
+            'name': 'punctuation.section.embedded.begin.puppet'
+          '2':
+            'name': 'source.puppet variable.other.readwrite.global.puppet'
+        'end': '}'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.section.embedded.end.puppet'
+        'contentName': 'source.puppet'
+        'name': 'meta.embedded.line.puppet'
+        'patterns': [
+          {
+            'include': '$self'
+          }
+        ]
+      }
+      {
+        'begin': '(\\${)(([a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)*)'
+        'beginCaptures':
+          '1':
+            'name': 'punctuation.section.embedded.begin.puppet'
+          '2':
+            'name': 'source.puppet variable.other.readwrite.global.puppet'
+        'end': '}'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.section.embedded.end.puppet'
+        'contentName': 'source.puppet'
+        'name': 'meta.embedded.line.puppet'
+        'patterns': [
+          {
+            'include': '$self'
+          }
+        ]
+      }
+      {
+        'begin': '\\${'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.section.embedded.begin.puppet'
+        'end': '}'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.section.embedded.end.puppet'
+        'contentName': 'source.puppet'
+        'name': 'meta.embedded.line.puppet'
+        'patterns': [
+          {
+            'include': '$self'
+          }
+        ]
       }
     ]
   'escaped_char':

--- a/generated-syntaxes/puppet.tmLanguage.cson
+++ b/generated-syntaxes/puppet.tmLanguage.cson
@@ -257,13 +257,71 @@ repository:
     endCaptures:
       "0":
         name: "punctuation.definition.string.end.puppet"
-    name: "string.quoted.double.puppet"
+    name: "string.quoted.double.interpolated.puppet"
     patterns: [
       {
         include: "#escaped_char"
       }
       {
-        include: "#variable"
+        include: "#interpolated_puppet"
+      }
+    ]
+  interpolated_puppet:
+    patterns: [
+      {
+        begin: "(\\${)(_[a-zA-Z0-9_]*)"
+        beginCaptures:
+          "1":
+            name: "punctuation.section.embedded.begin.puppet"
+          "2":
+            name: "source.puppet variable.other.readwrite.global.puppet"
+        end: "}"
+        endCaptures:
+          "0":
+            name: "punctuation.section.embedded.end.puppet"
+        contentName: "source.puppet"
+        name: "meta.embedded.line.puppet"
+        patterns: [
+          {
+            include: "$self"
+          }
+        ]
+      }
+      {
+        begin: "(\\${)(([a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)*)"
+        beginCaptures:
+          "1":
+            name: "punctuation.section.embedded.begin.puppet"
+          "2":
+            name: "source.puppet variable.other.readwrite.global.puppet"
+        end: "}"
+        endCaptures:
+          "0":
+            name: "punctuation.section.embedded.end.puppet"
+        contentName: "source.puppet"
+        name: "meta.embedded.line.puppet"
+        patterns: [
+          {
+            include: "$self"
+          }
+        ]
+      }
+      {
+        begin: "\\${"
+        beginCaptures:
+          "0":
+            name: "punctuation.section.embedded.begin.puppet"
+        end: "}"
+        endCaptures:
+          "0":
+            name: "punctuation.section.embedded.end.puppet"
+        contentName: "source.puppet"
+        name: "meta.embedded.line.puppet"
+        patterns: [
+          {
+            include: "$self"
+          }
+        ]
       }
     ]
   escaped_char:

--- a/generated-syntaxes/puppet.tmLanguage.cson
+++ b/generated-syntaxes/puppet.tmLanguage.cson
@@ -490,20 +490,18 @@ repository:
   variable:
     patterns: [
       {
+        match: "(\\$)_[a-zA-Z0-9_]*"
+        name: "variable.other.readwrite.global.puppet"
         captures:
           "1":
             name: "punctuation.definition.variable.puppet"
-        match: "(\\$)((::)?[a-z]\\w*)*((::)?[a-z_]\\w*)\\b"
-        name: "variable.other.readwrite.global.puppet"
       }
       {
+        match: "(\\$)(([a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)*)"
+        name: "variable.other.readwrite.global.puppet"
         captures:
           "1":
             name: "punctuation.definition.variable.puppet"
-          "2":
-            name: "punctuation.definition.variable.puppet"
-        match: "(\\$\\{)(?:[a-zA-Zx7f-xff\\$]|::)(?:[a-zA-Z0-9_x7f-xff\\$]|::)*(\\})"
-        name: "variable.other.readwrite.global.puppet"
       }
     ]
   function_call:

--- a/generated-syntaxes/puppet.tmLanguage.json
+++ b/generated-syntaxes/puppet.tmLanguage.json
@@ -583,25 +583,22 @@
     "variable": {
       "patterns": [
         {
+          "match": "(\\$)_[a-zA-Z0-9_]*",
+          "name": "variable.other.readwrite.global.puppet",
           "captures": {
             "1": {
               "name": "punctuation.definition.variable.puppet"
             }
-          },
-          "match": "(\\$)((::)?[a-z]\\w*)*((::)?[a-z_]\\w*)\\b",
-          "name": "variable.other.readwrite.global.puppet"
+          }
         },
         {
+          "match": "(\\$)(([a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)*)",
+          "name": "variable.other.readwrite.global.puppet",
           "captures": {
             "1": {
               "name": "punctuation.definition.variable.puppet"
-            },
-            "2": {
-              "name": "punctuation.definition.variable.puppet"
             }
-          },
-          "match": "(\\$\\{)(?:[a-zA-Zx7f-xff\\$]|::)(?:[a-zA-Z0-9_x7f-xff\\$]|::)*(\\})",
-          "name": "variable.other.readwrite.global.puppet"
+          }
         }
       ]
     },

--- a/generated-syntaxes/puppet.tmLanguage.json
+++ b/generated-syntaxes/puppet.tmLanguage.json
@@ -306,13 +306,86 @@
           "name": "punctuation.definition.string.end.puppet"
         }
       },
-      "name": "string.quoted.double.puppet",
+      "name": "string.quoted.double.interpolated.puppet",
       "patterns": [
         {
           "include": "#escaped_char"
         },
         {
-          "include": "#variable"
+          "include": "#interpolated_puppet"
+        }
+      ]
+    },
+    "interpolated_puppet": {
+      "patterns": [
+        {
+          "begin": "(\\${)(_[a-zA-Z0-9_]*)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.section.embedded.begin.puppet"
+            },
+            "2": {
+              "name": "source.puppet variable.other.readwrite.global.puppet"
+            }
+          },
+          "end": "}",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.section.embedded.end.puppet"
+            }
+          },
+          "contentName": "source.puppet",
+          "name": "meta.embedded.line.puppet",
+          "patterns": [
+            {
+              "include": "$self"
+            }
+          ]
+        },
+        {
+          "begin": "(\\${)(([a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)*)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.section.embedded.begin.puppet"
+            },
+            "2": {
+              "name": "source.puppet variable.other.readwrite.global.puppet"
+            }
+          },
+          "end": "}",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.section.embedded.end.puppet"
+            }
+          },
+          "contentName": "source.puppet",
+          "name": "meta.embedded.line.puppet",
+          "patterns": [
+            {
+              "include": "$self"
+            }
+          ]
+        },
+        {
+          "begin": "\\${",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.section.embedded.begin.puppet"
+            }
+          },
+          "end": "}",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.section.embedded.end.puppet"
+            }
+          },
+          "contentName": "source.puppet",
+          "name": "meta.embedded.line.puppet",
+          "patterns": [
+            {
+              "include": "$self"
+            }
+          ]
         }
       ]
     },

--- a/generated-syntaxes/puppet.tmLanguage.yaml
+++ b/generated-syntaxes/puppet.tmLanguage.yaml
@@ -313,18 +313,16 @@ repository:
         name: constant.numeric.integer.puppet
   variable:
     patterns:
-      - captures:
+      - match: '(\$)_[a-zA-Z0-9_]*'
+        name: variable.other.readwrite.global.puppet
+        captures:
           '1':
             name: punctuation.definition.variable.puppet
-        match: '(\$)((::)?[a-z]\w*)*((::)?[a-z_]\w*)\b'
+      - match: '(\$)(([a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)*)'
         name: variable.other.readwrite.global.puppet
-      - captures:
+        captures:
           '1':
             name: punctuation.definition.variable.puppet
-          '2':
-            name: punctuation.definition.variable.puppet
-        match: '(\$\{)(?:[a-zA-Zx7f-xff\$]|::)(?:[a-zA-Z0-9_x7f-xff\$]|::)*(\})'
-        name: variable.other.readwrite.global.puppet
   function_call:
     begin: '([a-zA-Z_][a-zA-Z0-9_]*)(\()'
     end: \)

--- a/generated-syntaxes/puppet.tmLanguage.yaml
+++ b/generated-syntaxes/puppet.tmLanguage.yaml
@@ -169,10 +169,52 @@ repository:
     endCaptures:
       '0':
         name: punctuation.definition.string.end.puppet
-    name: string.quoted.double.puppet
+    name: string.quoted.double.interpolated.puppet
     patterns:
       - include: '#escaped_char'
-      - include: '#variable'
+      - include: '#interpolated_puppet'
+  interpolated_puppet:
+    patterns:
+      - begin: '(\${)(_[a-zA-Z0-9_]*)'
+        beginCaptures:
+          '1':
+            name: punctuation.section.embedded.begin.puppet
+          '2':
+            name: source.puppet variable.other.readwrite.global.puppet
+        end: '}'
+        endCaptures:
+          '0':
+            name: punctuation.section.embedded.end.puppet
+        contentName: source.puppet
+        name: meta.embedded.line.puppet
+        patterns:
+          - include: $self
+      - begin: '(\${)(([a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)*)'
+        beginCaptures:
+          '1':
+            name: punctuation.section.embedded.begin.puppet
+          '2':
+            name: source.puppet variable.other.readwrite.global.puppet
+        end: '}'
+        endCaptures:
+          '0':
+            name: punctuation.section.embedded.end.puppet
+        contentName: source.puppet
+        name: meta.embedded.line.puppet
+        patterns:
+          - include: $self
+      - begin: '\${'
+        beginCaptures:
+          '0':
+            name: punctuation.section.embedded.begin.puppet
+        end: '}'
+        endCaptures:
+          '0':
+            name: punctuation.section.embedded.end.puppet
+        contentName: source.puppet
+        name: meta.embedded.line.puppet
+        patterns:
+          - include: $self
   escaped_char:
     match: \\.
     name: constant.character.escape.puppet

--- a/syntaxes/puppet.tmLanguage
+++ b/syntaxes/puppet.tmLanguage
@@ -485,7 +485,7 @@
         </dict>
       </dict>
       <key>name</key>
-      <string>string.quoted.double.puppet</string>
+      <string>string.quoted.double.interpolated.puppet</string>
       <key>patterns</key>
       <array>
         <dict>
@@ -494,7 +494,127 @@
         </dict>
         <dict>
           <key>include</key>
-          <string>#variable</string>
+          <string>#interpolated_puppet</string>
+        </dict>
+      </array>
+    </dict>
+    <!-- Ref: https://puppet.com/docs/puppet/latest/lang_data_string.html#short-forms-for-variable-interpolation -->
+    <key>interpolated_puppet</key>
+    <dict>
+      <key>patterns</key>
+      <array>
+        <!-- These definitions are the #variable matches but expressed as an interpolated string sequence e.g. ${var::foo .... } -->
+        <!-- Short variable names can start with underscore e.g. "${_foo1}", "${_foo2.split(..)}" -->
+        <dict>
+          <key>begin</key>
+          <string>(\${)(_[a-zA-Z0-9_]*)</string>
+          <key>beginCaptures</key>
+          <dict>
+            <key>1</key>
+            <dict>
+              <key>name</key>
+              <string>punctuation.section.embedded.begin.puppet</string>
+            </dict>
+            <key>2</key>
+            <dict>
+              <key>name</key>
+              <string>source.puppet variable.other.readwrite.global.puppet</string>
+            </dict>
+          </dict>
+          <key>end</key>
+          <string>}</string>
+          <key>endCaptures</key>
+          <dict>
+            <key>0</key>
+            <dict>
+              <key>name</key>
+              <string>punctuation.section.embedded.end.puppet</string>
+            </dict>
+          </dict>
+          <key>contentName</key>
+          <string>source.puppet</string>
+          <key>name</key>
+          <string>meta.embedded.line.puppet</string>
+          <key>patterns</key>
+          <array>
+            <dict>
+              <key>include</key>
+              <string>$self</string>
+            </dict>
+          </array>
+        </dict>
+        <!-- Qualified variable names (Can't start with underscore) -->
+        <dict>
+          <key>begin</key>
+          <string>(\${)(([a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)*)</string>
+          <key>beginCaptures</key>
+          <dict>
+            <key>1</key>
+            <dict>
+              <key>name</key>
+              <string>punctuation.section.embedded.begin.puppet</string>
+            </dict>
+            <key>2</key>
+            <dict>
+              <key>name</key>
+              <string>source.puppet variable.other.readwrite.global.puppet</string>
+            </dict>
+          </dict>
+          <key>end</key>
+          <string>}</string>
+          <key>endCaptures</key>
+          <dict>
+            <key>0</key>
+            <dict>
+              <key>name</key>
+              <string>punctuation.section.embedded.end.puppet</string>
+            </dict>
+          </dict>
+          <key>contentName</key>
+          <string>source.puppet</string>
+          <key>name</key>
+          <string>meta.embedded.line.puppet</string>
+          <key>patterns</key>
+          <array>
+            <dict>
+              <key>include</key>
+              <string>$self</string>
+            </dict>
+          </array>
+        </dict>
+        <!-- Catchall. Includes variables with leading $ -->
+        <dict>
+          <key>begin</key>
+          <string>\${</string>
+          <key>beginCaptures</key>
+          <dict>
+            <key>0</key>
+            <dict>
+              <key>name</key>
+              <string>punctuation.section.embedded.begin.puppet</string>
+            </dict>
+          </dict>
+          <key>end</key>
+          <string>}</string>
+          <key>endCaptures</key>
+          <dict>
+            <key>0</key>
+            <dict>
+              <key>name</key>
+              <string>punctuation.section.embedded.end.puppet</string>
+            </dict>
+          </dict>
+          <key>contentName</key>
+          <string>source.puppet</string>
+          <key>name</key>
+          <string>meta.embedded.line.puppet</string>
+          <key>patterns</key>
+          <array>
+            <dict>
+              <key>include</key>
+              <string>$self</string>
+            </dict>
+          </array>
         </dict>
       </array>
     </dict>

--- a/syntaxes/puppet.tmLanguage
+++ b/syntaxes/puppet.tmLanguage
@@ -905,11 +905,17 @@
         </dict>
       </array>
     </dict>
+    <!-- Ref: https://puppet.com/docs/puppet/latest/lang_variables.html#regular-expressions-for-variable-names -->
     <key>variable</key>
     <dict>
       <key>patterns</key>
       <array>
+        <!--Short variable names can start with underscore -->
         <dict>
+          <key>match</key>
+          <string>(\$)_[a-zA-Z0-9_]*</string>
+          <key>name</key>
+          <string>variable.other.readwrite.global.puppet</string>
           <key>captures</key>
           <dict>
             <key>1</key>
@@ -918,12 +924,13 @@
               <string>punctuation.definition.variable.puppet</string>
             </dict>
           </dict>
-          <key>match</key>
-          <string>(\$)((::)?[a-z]\w*)*((::)?[a-z_]\w*)\b</string>
-          <key>name</key>
-          <string>variable.other.readwrite.global.puppet</string>
         </dict>
+        <!-- Qualified variable names (Can't start with underscore) -->
         <dict>
+          <key>match</key>
+          <string>(\$)(([a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)*)</string>
+          <key>name</key>
+          <string>variable.other.readwrite.global.puppet</string>
           <key>captures</key>
           <dict>
             <key>1</key>
@@ -931,16 +938,7 @@
               <key>name</key>
               <string>punctuation.definition.variable.puppet</string>
             </dict>
-            <key>2</key>
-            <dict>
-              <key>name</key>
-              <string>punctuation.definition.variable.puppet</string>
-            </dict>
           </dict>
-          <key>match</key>
-          <string>(\$\{)(?:[a-zA-Zx7f-xff\$]|::)(?:[a-zA-Z0-9_x7f-xff\$]|::)*(\})</string>
-          <key>name</key>
-          <string>variable.other.readwrite.global.puppet</string>
         </dict>
       </array>
     </dict>


### PR DESCRIPTION
Previously combinations of valid and invalid variable names were being
highlighted incorrectly, for example names starting with underscore.  This
commit updates the variable regex matchers to align with the Puppet Language
and adds tests for both valid and invalid variable name highlighting.

---

Previously interpolated text within strings would not highlight correctly on
various combinations of valid and invalid variable names and function calls, for
example names starting with underscore.  This commit updates the variable regex
matchers to align with the Puppet Language and ensures that the highlighting
looks correct.

Also note that the use of the contentName = source.puppet token.  This is used
to "reset" the token list for editors so the colouring can be set correctly.
This commit also adds tests for valid variable names within different sections
of an interpolated string.

---

Fixes #16 

Reminder

- [x] Added Tests

- [x] Ran `npm run convert` and committed the changes too
