### PR TITLE
(GH-22) Fix tokenizing of heredoc strings

### DIFF
--- a/generated-syntaxes/puppet.tmLanguage.atom.cson
+++ b/generated-syntaxes/puppet.tmLanguage.atom.cson
@@ -186,10 +186,13 @@
     'name': 'keyword.control.puppet'
   }
   {
-    'include': '#puppet-datatypes'
+    'include': '#heredoc'
   }
   {
     'include': '#strings'
+  }
+  {
+    'include': '#puppet-datatypes'
   }
   {
     'include': '#array'
@@ -587,3 +590,36 @@
     'match': '(\\/)(.+)(?:\\/)'
     'name': 'string.regexp.literal.puppet'
     'comment': 'Puppet Regular expression literal without interpolation'
+  'heredoc':
+    'patterns': [
+      {
+        'begin': '@\\([[:blank:]]*"([^:\\/) \\t]+)"[[:blank:]]*(:[[:blank:]]*[a-z][a-zA-Z0-9_+]*[[:blank:]]*)?(\\/[[:blank:]]*[tsrnL$]*)?[[:blank:]]*\\)'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.string.begin.puppet'
+        'end': '^[[:blank:]]*(\\|-|\\||-)?[[:blank:]]*\\1'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.string.end.puppet'
+        'name': 'string.interpolated.heredoc.puppet'
+        'patterns': [
+          {
+            'include': '#escaped_char'
+          }
+          {
+            'include': '#interpolated_puppet'
+          }
+        ]
+      }
+      {
+        'begin': '@\\([[:blank:]]*([^:\\/) \\t]+)[[:blank:]]*(:[[:blank:]]*[a-z][a-zA-Z0-9_+]*[[:blank:]]*)?(\\/[[:blank:]]*[tsrnL$]*)?[[:blank:]]*\\)'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.string.begin.puppet'
+        'end': '^[[:blank:]]*(\\|-|\\||-)?[[:blank:]]*\\1'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.string.end.puppet'
+        'name': 'string.unquoted.heredoc.puppet'
+      }
+    ]

--- a/generated-syntaxes/puppet.tmLanguage.cson
+++ b/generated-syntaxes/puppet.tmLanguage.cson
@@ -186,10 +186,13 @@ patterns: [
     name: "keyword.control.puppet"
   }
   {
-    include: "#puppet-datatypes"
+    include: "#heredoc"
   }
   {
     include: "#strings"
+  }
+  {
+    include: "#puppet-datatypes"
   }
   {
     include: "#array"
@@ -587,3 +590,36 @@ repository:
     match: "(\\/)(.+)(?:\\/)"
     name: "string.regexp.literal.puppet"
     comment: "Puppet Regular expression literal without interpolation"
+  heredoc:
+    patterns: [
+      {
+        begin: "@\\([[:blank:]]*\"([^:\\/) \\t]+)\"[[:blank:]]*(:[[:blank:]]*[a-z][a-zA-Z0-9_+]*[[:blank:]]*)?(\\/[[:blank:]]*[tsrnL$]*)?[[:blank:]]*\\)"
+        beginCaptures:
+          "0":
+            name: "punctuation.definition.string.begin.puppet"
+        end: "^[[:blank:]]*(\\|-|\\||-)?[[:blank:]]*\\1"
+        endCaptures:
+          "0":
+            name: "punctuation.definition.string.end.puppet"
+        name: "string.interpolated.heredoc.puppet"
+        patterns: [
+          {
+            include: "#escaped_char"
+          }
+          {
+            include: "#interpolated_puppet"
+          }
+        ]
+      }
+      {
+        begin: "@\\([[:blank:]]*([^:\\/) \\t]+)[[:blank:]]*(:[[:blank:]]*[a-z][a-zA-Z0-9_+]*[[:blank:]]*)?(\\/[[:blank:]]*[tsrnL$]*)?[[:blank:]]*\\)"
+        beginCaptures:
+          "0":
+            name: "punctuation.definition.string.begin.puppet"
+        end: "^[[:blank:]]*(\\|-|\\||-)?[[:blank:]]*\\1"
+        endCaptures:
+          "0":
+            name: "punctuation.definition.string.end.puppet"
+        name: "string.unquoted.heredoc.puppet"
+      }
+    ]

--- a/generated-syntaxes/puppet.tmLanguage.json
+++ b/generated-syntaxes/puppet.tmLanguage.json
@@ -228,10 +228,13 @@
       "name": "keyword.control.puppet"
     },
     {
-      "include": "#puppet-datatypes"
+      "include": "#heredoc"
     },
     {
       "include": "#strings"
+    },
+    {
+      "include": "#puppet-datatypes"
     },
     {
       "include": "#array"
@@ -702,6 +705,48 @@
       "match": "(\\/)(.+)(?:\\/)",
       "name": "string.regexp.literal.puppet",
       "comment": "Puppet Regular expression literal without interpolation"
+    },
+    "heredoc": {
+      "patterns": [
+        {
+          "begin": "@\\([[:blank:]]*\"([^:\\/) \\t]+)\"[[:blank:]]*(:[[:blank:]]*[a-z][a-zA-Z0-9_+]*[[:blank:]]*)?(\\/[[:blank:]]*[tsrnL$]*)?[[:blank:]]*\\)",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.puppet"
+            }
+          },
+          "end": "^[[:blank:]]*(\\|-|\\||-)?[[:blank:]]*\\1",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.puppet"
+            }
+          },
+          "name": "string.interpolated.heredoc.puppet",
+          "patterns": [
+            {
+              "include": "#escaped_char"
+            },
+            {
+              "include": "#interpolated_puppet"
+            }
+          ]
+        },
+        {
+          "begin": "@\\([[:blank:]]*([^:\\/) \\t]+)[[:blank:]]*(:[[:blank:]]*[a-z][a-zA-Z0-9_+]*[[:blank:]]*)?(\\/[[:blank:]]*[tsrnL$]*)?[[:blank:]]*\\)",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.puppet"
+            }
+          },
+          "end": "^[[:blank:]]*(\\|-|\\||-)?[[:blank:]]*\\1",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.puppet"
+            }
+          },
+          "name": "string.unquoted.heredoc.puppet"
+        }
+      ]
     }
   }
 }

--- a/generated-syntaxes/puppet.tmLanguage.yaml
+++ b/generated-syntaxes/puppet.tmLanguage.yaml
@@ -129,8 +129,9 @@ patterns:
     name: meta.definition.resource.puppet
   - match: '\b(case|if|else|elsif|unless)(?!::)\b'
     name: keyword.control.puppet
-  - include: '#puppet-datatypes'
+  - include: '#heredoc'
   - include: '#strings'
+  - include: '#puppet-datatypes'
   - include: '#array'
   - match: '((\$?)"?[a-zA-Z_\x{7f}-\x{ff}][a-zA-Z0-9_\x{7f}-\x{ff}]*"?):(?=\s+|$)'
     name: entity.name.section.puppet
@@ -382,4 +383,27 @@ repository:
     match: '(\/)(.+)(?:\/)'
     name: string.regexp.literal.puppet
     comment: Puppet Regular expression literal without interpolation
+  heredoc:
+    patterns:
+      - begin: '@\([[:blank:]]*"([^:\/) \t]+)"[[:blank:]]*(:[[:blank:]]*[a-z][a-zA-Z0-9_+]*[[:blank:]]*)?(\/[[:blank:]]*[tsrnL$]*)?[[:blank:]]*\)'
+        beginCaptures:
+          '0':
+            name: punctuation.definition.string.begin.puppet
+        end: '^[[:blank:]]*(\|-|\||-)?[[:blank:]]*\1'
+        endCaptures:
+          '0':
+            name: punctuation.definition.string.end.puppet
+        name: string.interpolated.heredoc.puppet
+        patterns:
+          - include: '#escaped_char'
+          - include: '#interpolated_puppet'
+      - begin: '@\([[:blank:]]*([^:\/) \t]+)[[:blank:]]*(:[[:blank:]]*[a-z][a-zA-Z0-9_+]*[[:blank:]]*)?(\/[[:blank:]]*[tsrnL$]*)?[[:blank:]]*\)'
+        beginCaptures:
+          '0':
+            name: punctuation.definition.string.begin.puppet
+        end: '^[[:blank:]]*(\|-|\||-)?[[:blank:]]*\1'
+        endCaptures:
+          '0':
+            name: punctuation.definition.string.end.puppet
+        name: string.unquoted.heredoc.puppet
 

--- a/syntaxes/puppet.tmLanguage
+++ b/syntaxes/puppet.tmLanguage
@@ -367,11 +367,15 @@
     </dict>
     <dict>
       <key>include</key>
-      <string>#puppet-datatypes</string>
+      <string>#heredoc</string>
     </dict>
     <dict>
       <key>include</key>
       <string>#strings</string>
+    </dict>
+    <dict>
+      <key>include</key>
+      <string>#puppet-datatypes</string>
     </dict>
     <dict>
       <key>include</key>
@@ -1107,6 +1111,74 @@
       <string>string.regexp.literal.puppet</string>
       <key>comment</key>
       <string>Puppet Regular expression literal without interpolation</string>
+    </dict>
+    <!-- Ref: https://puppet.com/docs/puppet/latest/lang_variables.html#regular-expressions-for-variable-names -->
+    <key>heredoc</key>
+    <dict>
+      <key>patterns</key>
+      <array>
+        <!-- Heredoc with interpolation e.g. @( END : abc / ts ) -->
+        <dict>
+          <key>begin</key>
+          <string>@\([[:blank:]]*"([^:\/) \t]+)"[[:blank:]]*(:[[:blank:]]*[a-z][a-zA-Z0-9_+]*[[:blank:]]*)?(\/[[:blank:]]*[tsrnL$]*)?[[:blank:]]*\)</string>
+          <key>beginCaptures</key>
+          <dict>
+            <key>0</key>
+            <dict>
+              <key>name</key>
+              <string>punctuation.definition.string.begin.puppet</string>
+            </dict>
+          </dict>
+          <key>end</key>
+          <string>^[[:blank:]]*(\|-|\||-)?[[:blank:]]*\1</string>
+          <key>endCaptures</key>
+          <dict>
+            <key>0</key>
+            <dict>
+              <key>name</key>
+              <string>punctuation.definition.string.end.puppet</string>
+            </dict>
+          </dict>
+          <key>name</key>
+          <string>string.interpolated.heredoc.puppet</string>
+          <key>patterns</key>
+          <array>
+            <dict>
+              <key>include</key>
+              <string>#escaped_char</string>
+            </dict>
+            <dict>
+              <key>include</key>
+              <string>#interpolated_puppet</string>
+            </dict>
+          </array>
+        </dict>
+        <!-- Heredoc without interpolation e.g. @( END : abc / ts ) -->
+        <dict>
+          <key>begin</key>
+          <string>@\([[:blank:]]*([^:\/) \t]+)[[:blank:]]*(:[[:blank:]]*[a-z][a-zA-Z0-9_+]*[[:blank:]]*)?(\/[[:blank:]]*[tsrnL$]*)?[[:blank:]]*\)</string>
+          <key>beginCaptures</key>
+          <dict>
+            <key>0</key>
+            <dict>
+              <key>name</key>
+              <string>punctuation.definition.string.begin.puppet</string>
+            </dict>
+          </dict>
+          <key>end</key>
+          <string>^[[:blank:]]*(\|-|\||-)?[[:blank:]]*\1</string>
+          <key>endCaptures</key>
+          <dict>
+            <key>0</key>
+            <dict>
+              <key>name</key>
+              <string>punctuation.definition.string.end.puppet</string>
+            </dict>
+          </dict>
+          <key>name</key>
+          <string>string.unquoted.heredoc.puppet</string>
+        </dict>
+      </array>
     </dict>
   </dict>
 </dict>


### PR DESCRIPTION
Previously the syntax did not understand heredoc strings.  This commit updates
the language to parse bare and interpolated heredoc strings as per [1].

Note however that this does not tokenize multiple heredocs on the same line or
using heredocs as string types which can then have functions on the right hand
side. [2] [3]

[1] https://github.com/puppetlabs/puppet-specifications/blob/master/language/heredoc.md
[2] https://github.com/puppetlabs/puppet-specifications/blob/master/language/heredoc.md#multiple-heredoc-on-the-same-line
[3] https://github.com/puppetlabs/puppet-specifications/blob/master/language/heredoc.md#additional-semantics

Fixes #22

---

Reminder

- [x] Added Tests

- [x] Ran `npm run convert` and committed the changes too
