### PR TITLE
(maint) Make regex matching lazy for syntax highlighting

### DIFF
--- a/generated-syntaxes/puppet.tmLanguage.atom.cson
+++ b/generated-syntaxes/puppet.tmLanguage.atom.cson
@@ -587,7 +587,7 @@
       }
     ]
   'regex-literal':
-    'match': '(\\/)(.+)(?:\\/)'
+    'match': '(\\/)(.+?)(?:[^\\\\]\\/)'
     'name': 'string.regexp.literal.puppet'
     'comment': 'Puppet Regular expression literal without interpolation'
   'heredoc':

--- a/generated-syntaxes/puppet.tmLanguage.cson
+++ b/generated-syntaxes/puppet.tmLanguage.cson
@@ -587,7 +587,7 @@ repository:
       }
     ]
   "regex-literal":
-    match: "(\\/)(.+)(?:\\/)"
+    match: "(\\/)(.+?)(?:[^\\\\]\\/)"
     name: "string.regexp.literal.puppet"
     comment: "Puppet Regular expression literal without interpolation"
   heredoc:

--- a/generated-syntaxes/puppet.tmLanguage.json
+++ b/generated-syntaxes/puppet.tmLanguage.json
@@ -702,7 +702,7 @@
       ]
     },
     "regex-literal": {
-      "match": "(\\/)(.+)(?:\\/)",
+      "match": "(\\/)(.+?)(?:[^\\\\]\\/)",
       "name": "string.regexp.literal.puppet",
       "comment": "Puppet Regular expression literal without interpolation"
     },

--- a/generated-syntaxes/puppet.tmLanguage.yaml
+++ b/generated-syntaxes/puppet.tmLanguage.yaml
@@ -380,7 +380,7 @@ repository:
         match: '(?<![a-zA-Z\$])([A-Z][a-zA-Z0-9]*)(?![a-zA-Z0-9])'
         name: storage.type.puppet
   regex-literal:
-    match: '(\/)(.+)(?:\/)'
+    match: '(\/)(.+?)(?:[^\\]\/)'
     name: string.regexp.literal.puppet
     comment: Puppet Regular expression literal without interpolation
   heredoc:

--- a/syntaxes/puppet.tmLanguage
+++ b/syntaxes/puppet.tmLanguage
@@ -1106,7 +1106,7 @@
     <key>regex-literal</key>
     <dict>
       <key>match</key>
-      <string>(\/)(.+)(?:\/)</string>
+      <string>(\/)(.+?)(?:[^\\]\/)</string>
       <key>name</key>
       <string>string.regexp.literal.puppet</string>
       <key>comment</key>

--- a/tests/syntaxes/puppet.tmLanguage.js
+++ b/tests/syntaxes/puppet.tmLanguage.js
@@ -355,6 +355,7 @@ describe('puppet.tmLanguage', function() {
       'in basic variable assignment': { 'manifest': "$foo = /abc123/", 'expectedTokenIndex': 3, 'expectedRegExText': 'abc123' },
       'in basic if statement': { 'manifest': "if 'foo' =~ /walrus/ {\n  $walrus = true\n}", 'expectedTokenIndex': 6, 'expectedRegExText': 'walrus' },
       'with special characters': { 'manifest': "$foo = /ab\\c#12\\/3/\n$bar = 'wee'", 'expectedTokenIndex': 3, 'expectedRegExText': 'ab\\c#12\\/3' },
+      'in the same line with other slashes': { 'manifest': "/puppet-agent-5\..*/ => 'puppet5/',", 'expectedTokenIndex': 0, 'expectedRegExText': 'puppet-agent-5\..*' },
     }
 
     for(var contextName in contexts) {
@@ -546,12 +547,12 @@ describe('puppet.tmLanguage', function() {
           if (startTokenText === undefined) { startTokenText = "@(" + start + ")" }
           if (end === undefined) { end = 'END'; }
           if (endTokenText === undefined) { endTokenText = end }
-  
+
           it("does not tokenizes a " + contextName + " heredoc", function() {
             var heredocStart = "@(" + start + ")"
             var heredocEnd = end
             var tokens = getLineTokens(grammar, "$foo = " + heredocStart + "\nText goes here\n" + end + "\n$foo = 'bar'");
-  
+
             // Expect that the heredoc is not tokenized
             expect(tokens[4]).to.not.eql({value: "\nText goes here\n", scopes: ['source.puppet', 'string.unquoted.heredoc.puppet']});
             expect(tokens[5]).to.not.eql({value: endTokenText, scopes: ['source.puppet', 'string.unquoted.heredoc.puppet', 'punctuation.definition.string.end.puppet']});
@@ -631,7 +632,7 @@ describe('puppet.tmLanguage', function() {
           if (startTokenText === undefined) { startTokenText = "@(" + start + ")" }
           if (end === undefined) { end = 'END'; }
           if (endTokenText === undefined) { endTokenText = end }
-  
+
           it("does not tokenizes a " + contextName + " heredoc", function() {
             var heredocStart = "@(" + start + ")"
             var heredocEnd = end
@@ -645,6 +646,6 @@ describe('puppet.tmLanguage', function() {
     });
   });
 
-  
-  
+
+
 });


### PR DESCRIPTION
The regex used to match regexes in puppet uses (.+) to match one or more of
anything in between two slashes. However, if there is another slash anywhere
on the line after the regex the (.+) will match between the first slash of the
regex and the other slash that's not part of the regex.

An example:

/puppet-agent-5..*/ => 'puppet5/',

In that line the syntax highlighter will match everything between the first
slash of the regex and the slash in the string as one regex.

This commit changes the match to the following:

1: The (.+) matcher is made to be 'lazy' so that it matches the smallest
string possible.

2: The final matcher (?:\/) is updated to include the negated set including
the backslash so that the final matcher matches a final slash with a
preceeding token that's anything _except_ \.

This should make the regex match the smallest possible string that begins with
/ and ends with / but does not end with \/.