### PR TITLE
(maint) Prepare for 1.3.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## Unreleased
 
+## [1.3.1] - 2018-03-28
+
+### Fixed
+- ([Commit](https://github.com/lingua-pupuli/puppet-editor-syntax/commit/ed18062cc9d904492f02d63b6553e1cadc95664e)) Make regex lazy for syntax highlighting
+
 ## [1.3.0] - 2018-11-29
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-editor-syntax",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This commit prepares the project for a 1.3.1 release

Note - the branch name has 1.4.0 but it is really a 1.3.1 release