### PR TITLE
(GH-30) Highlight regex capture variables

### DIFF
--- a/generated-syntaxes/puppet.tmLanguage.atom.cson
+++ b/generated-syntaxes/puppet.tmLanguage.atom.cson
@@ -182,6 +182,15 @@
     'name': 'meta.definition.resource.puppet'
   }
   {
+    'match': '^\\s*(\\w+)\\s*{\\s*(\\$(\\d+))\\s*:'
+    'captures':
+      '1':
+        'name': 'storage.type.puppet'
+      '2':
+        'name': 'entity.name.section.puppet'
+    'name': 'meta.definition.resource.puppet'
+  }
+  {
     'match': '\\b(case|if|else|elsif|unless)(?!::)\\b'
     'name': 'keyword.control.puppet'
   }
@@ -271,6 +280,25 @@
     ]
   'interpolated_puppet':
     'patterns': [
+      {
+        'begin': '(\\${)(\\d+)'
+        'beginCaptures':
+          '1':
+            'name': 'punctuation.section.embedded.begin.puppet'
+          '2':
+            'name': 'source.puppet variable.other.readwrite.global.pre-defined.puppet'
+        'end': '}'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.section.embedded.end.puppet'
+        'contentName': 'source.puppet'
+        'name': 'meta.embedded.line.puppet'
+        'patterns': [
+          {
+            'include': '$self'
+          }
+        ]
+      }
       {
         'begin': '(\\${)(_[a-zA-Z0-9_]*)'
         'beginCaptures':
@@ -550,6 +578,13 @@
     ]
   'variable':
     'patterns': [
+      {
+        'match': '(\\$)(\\d+)'
+        'name': 'variable.other.readwrite.global.pre-defined.puppet'
+        'captures':
+          '1':
+            'name': 'punctuation.definition.variable.puppet'
+      }
       {
         'match': '(\\$)_[a-zA-Z0-9_]*'
         'name': 'variable.other.readwrite.global.puppet'

--- a/generated-syntaxes/puppet.tmLanguage.cson
+++ b/generated-syntaxes/puppet.tmLanguage.cson
@@ -182,6 +182,15 @@ patterns: [
     name: "meta.definition.resource.puppet"
   }
   {
+    match: "^\\s*(\\w+)\\s*{\\s*(\\$(\\d+))\\s*:"
+    captures:
+      "1":
+        name: "storage.type.puppet"
+      "2":
+        name: "entity.name.section.puppet"
+    name: "meta.definition.resource.puppet"
+  }
+  {
     match: "\\b(case|if|else|elsif|unless)(?!::)\\b"
     name: "keyword.control.puppet"
   }
@@ -271,6 +280,25 @@ repository:
     ]
   interpolated_puppet:
     patterns: [
+      {
+        begin: "(\\${)(\\d+)"
+        beginCaptures:
+          "1":
+            name: "punctuation.section.embedded.begin.puppet"
+          "2":
+            name: "source.puppet variable.other.readwrite.global.pre-defined.puppet"
+        end: "}"
+        endCaptures:
+          "0":
+            name: "punctuation.section.embedded.end.puppet"
+        contentName: "source.puppet"
+        name: "meta.embedded.line.puppet"
+        patterns: [
+          {
+            include: "$self"
+          }
+        ]
+      }
       {
         begin: "(\\${)(_[a-zA-Z0-9_]*)"
         beginCaptures:
@@ -550,6 +578,13 @@ repository:
     ]
   variable:
     patterns: [
+      {
+        match: "(\\$)(\\d+)"
+        name: "variable.other.readwrite.global.pre-defined.puppet"
+        captures:
+          "1":
+            name: "punctuation.definition.variable.puppet"
+      }
       {
         match: "(\\$)_[a-zA-Z0-9_]*"
         name: "variable.other.readwrite.global.puppet"

--- a/generated-syntaxes/puppet.tmLanguage.json
+++ b/generated-syntaxes/puppet.tmLanguage.json
@@ -224,6 +224,18 @@
       "name": "meta.definition.resource.puppet"
     },
     {
+      "match": "^\\s*(\\w+)\\s*{\\s*(\\$(\\d+))\\s*:",
+      "captures": {
+        "1": {
+          "name": "storage.type.puppet"
+        },
+        "2": {
+          "name": "entity.name.section.puppet"
+        }
+      },
+      "name": "meta.definition.resource.puppet"
+    },
+    {
       "match": "\\b(case|if|else|elsif|unless)(?!::)\\b",
       "name": "keyword.control.puppet"
     },
@@ -321,6 +333,30 @@
     },
     "interpolated_puppet": {
       "patterns": [
+        {
+          "begin": "(\\${)(\\d+)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.section.embedded.begin.puppet"
+            },
+            "2": {
+              "name": "source.puppet variable.other.readwrite.global.pre-defined.puppet"
+            }
+          },
+          "end": "}",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.section.embedded.end.puppet"
+            }
+          },
+          "contentName": "source.puppet",
+          "name": "meta.embedded.line.puppet",
+          "patterns": [
+            {
+              "include": "$self"
+            }
+          ]
+        },
         {
           "begin": "(\\${)(_[a-zA-Z0-9_]*)",
           "beginCaptures": {
@@ -658,6 +694,15 @@
     },
     "variable": {
       "patterns": [
+        {
+          "match": "(\\$)(\\d+)",
+          "name": "variable.other.readwrite.global.pre-defined.puppet",
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.variable.puppet"
+            }
+          }
+        },
         {
           "match": "(\\$)_[a-zA-Z0-9_]*",
           "name": "variable.other.readwrite.global.puppet",

--- a/generated-syntaxes/puppet.tmLanguage.yaml
+++ b/generated-syntaxes/puppet.tmLanguage.yaml
@@ -127,6 +127,13 @@ patterns:
       '2':
         name: entity.name.section.puppet
     name: meta.definition.resource.puppet
+  - match: '^\s*(\w+)\s*{\s*(\$(\d+))\s*:'
+    captures:
+      '1':
+        name: storage.type.puppet
+      '2':
+        name: entity.name.section.puppet
+    name: meta.definition.resource.puppet
   - match: '\b(case|if|else|elsif|unless)(?!::)\b'
     name: keyword.control.puppet
   - include: '#heredoc'
@@ -176,6 +183,20 @@ repository:
       - include: '#interpolated_puppet'
   interpolated_puppet:
     patterns:
+      - begin: '(\${)(\d+)'
+        beginCaptures:
+          '1':
+            name: punctuation.section.embedded.begin.puppet
+          '2':
+            name: source.puppet variable.other.readwrite.global.pre-defined.puppet
+        end: '}'
+        endCaptures:
+          '0':
+            name: punctuation.section.embedded.end.puppet
+        contentName: source.puppet
+        name: meta.embedded.line.puppet
+        patterns:
+          - include: $self
       - begin: '(\${)(_[a-zA-Z0-9_]*)'
         beginCaptures:
           '1':
@@ -356,6 +377,11 @@ repository:
         name: constant.numeric.integer.puppet
   variable:
     patterns:
+      - match: (\$)(\d+)
+        name: variable.other.readwrite.global.pre-defined.puppet
+        captures:
+          '1':
+            name: punctuation.definition.variable.puppet
       - match: '(\$)_[a-zA-Z0-9_]*'
         name: variable.other.readwrite.global.puppet
         captures:

--- a/syntaxes/puppet.tmLanguage
+++ b/syntaxes/puppet.tmLanguage
@@ -321,6 +321,7 @@
         </dict>
       </array>
     </dict>
+    <!-- Resource definition using a string based name -->
     <dict>
       <key>captures</key>
       <dict>
@@ -340,9 +341,30 @@
       <key>name</key>
       <string>meta.definition.resource.puppet</string>
     </dict>
+    <!-- Resource definition using a user variable name -->
     <dict>
       <key>match</key>
       <string>^\s*(\w+)\s*{\s*(\$[a-zA-Z_]+)\s*:</string>
+      <key>captures</key>
+      <dict>
+        <key>1</key>
+        <dict>
+          <key>name</key>
+          <string>storage.type.puppet</string>
+        </dict>
+        <key>2</key>
+        <dict>
+          <key>name</key>
+          <string>entity.name.section.puppet</string>
+        </dict>
+      </dict>
+      <key>name</key>
+      <string>meta.definition.resource.puppet</string>
+    </dict>
+    <!-- Resource definition using a predefined name -->
+    <dict>
+      <key>match</key>
+      <string>^\s*(\w+)\s*{\s*(\$(\d+))\s*:</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -508,6 +530,46 @@
       <key>patterns</key>
       <array>
         <!-- These definitions are the #variable matches but expressed as an interpolated string sequence e.g. ${var::foo .... } -->
+        <!-- Predefined variables -->
+        <!-- Similar to https://github.com/rubyide/vscode-ruby/blob/bdad0449bfc12778e1a501c084443ae8f4c94066/syntaxes/ruby.cson.json#L212-L220 -->
+        <dict>
+          <key>begin</key>
+          <string>(\${)(\d+)</string>
+          <key>beginCaptures</key>
+          <dict>
+            <key>1</key>
+            <dict>
+              <key>name</key>
+              <string>punctuation.section.embedded.begin.puppet</string>
+            </dict>
+            <key>2</key>
+            <dict>
+              <key>name</key>
+              <string>source.puppet variable.other.readwrite.global.pre-defined.puppet</string>
+            </dict>
+          </dict>
+          <key>end</key>
+          <string>}</string>
+          <key>endCaptures</key>
+          <dict>
+            <key>0</key>
+            <dict>
+              <key>name</key>
+              <string>punctuation.section.embedded.end.puppet</string>
+            </dict>
+          </dict>
+          <key>contentName</key>
+          <string>source.puppet</string>
+          <key>name</key>
+          <string>meta.embedded.line.puppet</string>
+          <key>patterns</key>
+          <array>
+            <dict>
+              <key>include</key>
+              <string>$self</string>
+            </dict>
+          </array>
+        </dict>
         <!-- Short variable names can start with underscore e.g. "${_foo1}", "${_foo2.split(..)}" -->
         <dict>
           <key>begin</key>
@@ -1034,6 +1096,22 @@
     <dict>
       <key>patterns</key>
       <array>
+        <!-- Predefined variables -->
+        <!-- Similar to https://github.com/rubyide/vscode-ruby/blob/bdad0449bfc12778e1a501c084443ae8f4c94066/syntaxes/ruby.cson.json#L212-L220 -->
+        <dict>
+          <key>match</key>
+          <string>(\$)(\d+)</string>
+          <key>name</key>
+          <string>variable.other.readwrite.global.pre-defined.puppet</string>
+          <key>captures</key>
+          <dict>
+            <key>1</key>
+            <dict>
+              <key>name</key>
+              <string>punctuation.definition.variable.puppet</string>
+            </dict>
+          </dict>
+        </dict>
         <!--Short variable names can start with underscore -->
         <dict>
           <key>match</key>

--- a/tests/syntaxes/puppet.tmLanguage.js
+++ b/tests/syntaxes/puppet.tmLanguage.js
@@ -39,7 +39,6 @@ describe('puppet.tmLanguage', function() {
     });
   });
 
-
   describe('numbers', function() {
     var hexTestCases = ['0xff', '0xabcdef0123456789', '0x0']
     var integerTestCases = ['10', '0', '-9', '10000']
@@ -419,16 +418,10 @@ describe('puppet.tmLanguage', function() {
     };
   });
 
-  describe('interpolated strings', function() {
+  describe('predefined variable names', function() {
+    // Straight up variable names
     var contexts = {
-      'a short variable name'                                   : { 'testcase': "var" },
-      'a short variable name with underscore'                   : { 'testcase': "_var" },
-      'a qualified variable name'                               : { 'testcase': "ab12::cd34::var" },
-      'a qualified short variable name'                         : { 'testcase': "::var" },
-      'a variable with a hashtable reference'                   : { 'testcase': "facts['123']", 'varname': 'facts' },
-      'a short variable with a hashtable reference'             : { 'testcase': "_facts['123']", 'varname': '_facts' },
-      'a variable with a function call suffix'                  : { 'testcase': "abc123.split()", 'varname': 'abc123' },
-      'a variable with an underscore and a function call suffix': { 'testcase': "_abc123.split()", 'varname': '_abc123' },
+      'a regex match group' : { 'testcase': "1" },
     }
     for(var contextName in contexts) {
       context(contextName, function() {
@@ -437,215 +430,48 @@ describe('puppet.tmLanguage', function() {
         // A bit of magic, if the context doesn't define a varname, just use the testcase
         if (varname === undefined) { varname = testcase; }
 
-        var positionContexts = {
-          "whole string"             : { 'prefix': "",        'suffix': "",        'offset': 0 },
-          "right hand side of string": { 'prefix': "prefix ", 'suffix': "",        'offset': 1 },
-          "left hand side of string" : { 'prefix': "",        'suffix': " suffix", 'offset': 0 },
-          "inside of string"         : { 'prefix': "prefix ", 'suffix': " suffix", 'offset': 1 },
-        }
-        for(var posContextName in positionContexts) {
-          context(posContextName, function() {
-            var prefixText = positionContexts[posContextName]['prefix'];
-            var suffixText = positionContexts[posContextName]['suffix'];
-            var tokenOffset = positionContexts[posContextName]['offset'];
+        it("tokenizes " + contextName + " assignment entirely with preceding dollar sign", function() {
+          var tokens = getLineTokens(grammar, "$foo = $" + testcase);
 
-            it("tokenizes " + contextName + ", interpolated within double quotes", function() {
-              var tokens = getLineTokens(grammar, "$foo = \"" + prefixText + "${" + testcase + "}" + suffixText + "\"");
-              expect(tokens[5 + tokenOffset]).to.eql({value: varname, scopes: ['source.puppet', 'string.quoted.double.interpolated.puppet', 'meta.embedded.line.puppet', 'source.puppet', 'variable.other.readwrite.global.puppet']});
-            });
+          expect(tokens[3]).to.eql({value: '$', scopes: ['source.puppet', 'variable.other.readwrite.global.pre-defined.puppet', 'punctuation.definition.variable.puppet']});
+          expect(tokens[4]).to.eql({value: varname, scopes: ['source.puppet', 'variable.other.readwrite.global.pre-defined.puppet']});
+        });
 
-            it("tokenizes " + contextName + ", prefixed with dollarsign, interpolated within double quotes", function() {
-              var tokens = getLineTokens(grammar, "$foo = \"" + prefixText + "${$" + testcase + "}" + suffixText + "\"");
-              expect(tokens[5 + tokenOffset]).to.eql({value: '$', scopes:
-                ['source.puppet', 'string.quoted.double.interpolated.puppet', 'meta.embedded.line.puppet', 'source.puppet', 'variable.other.readwrite.global.puppet','punctuation.definition.variable.puppet']});
-              expect(tokens[6 + tokenOffset]).to.eql({value: varname, scopes:
-                ['source.puppet', 'string.quoted.double.interpolated.puppet', 'meta.embedded.line.puppet', 'source.puppet', 'variable.other.readwrite.global.puppet']});
+        it("tokenizes " + contextName + " as a resource name", function() {
+          var tokens = getLineTokens(grammar, "user { $" + testcase + ":\n}\n");
+
+          expect(tokens[2]).to.eql({value: '$' + varname, scopes: ['source.puppet', 'meta.definition.resource.puppet', 'entity.name.section.puppet']});
+        });
+
+        describe('interpolated strings', function() {
+          var positionContexts = {
+            "whole string"             : { 'prefix': "",        'suffix': "",        'offset': 0 },
+            "right hand side of string": { 'prefix': "prefix ", 'suffix': "",        'offset': 1 },
+            "left hand side of string" : { 'prefix': "",        'suffix': " suffix", 'offset': 0 },
+            "inside of string"         : { 'prefix': "prefix ", 'suffix': " suffix", 'offset': 1 },
+          }
+          for(var posContextName in positionContexts) {
+            context(posContextName, function() {
+              var prefixText = positionContexts[posContextName]['prefix'];
+              var suffixText = positionContexts[posContextName]['suffix'];
+              var tokenOffset = positionContexts[posContextName]['offset'];
+
+              it("tokenizes " + contextName + ", interpolated within double quotes", function() {
+                var tokens = getLineTokens(grammar, "$foo = \"" + prefixText + "${" + testcase + "}" + suffixText + "\"");
+                expect(tokens[5 + tokenOffset]).to.eql({value: varname, scopes: ['source.puppet', 'string.quoted.double.interpolated.puppet', 'meta.embedded.line.puppet', 'source.puppet', 'variable.other.readwrite.global.pre-defined.puppet']});
+              });
+
+              it("tokenizes " + contextName + ", prefixed with dollarsign, interpolated within double quotes", function() {
+                var tokens = getLineTokens(grammar, "$foo = \"" + prefixText + "${$" + testcase + "}" + suffixText + "\"");
+                expect(tokens[5 + tokenOffset]).to.eql({value: '$', scopes:
+                  ['source.puppet', 'string.quoted.double.interpolated.puppet', 'meta.embedded.line.puppet', 'source.puppet', 'variable.other.readwrite.global.pre-defined.puppet','punctuation.definition.variable.puppet']});
+                expect(tokens[6 + tokenOffset]).to.eql({value: varname, scopes:
+                  ['source.puppet', 'string.quoted.double.interpolated.puppet', 'meta.embedded.line.puppet', 'source.puppet', 'variable.other.readwrite.global.pre-defined.puppet']});
+              });
             });
-          });
-        };
+          };
+        });
       });
     };
   });
-
-  describe('non-interpolated heredoc', function() {
-    var contexts = {
-      'start simple variation 1'     : { 'start': "END" },
-      'start simple variation 2'     : { 'start': "  END" },
-      'start simple variation 3'     : { 'start': "END  " },
-      'start simple variation 4'     : { 'start': "\tEND  " },
-      'start syntax variation 1'     : { 'start': "END:abc123" },
-      'start syntax variation 2'     : { 'start': "END: abc123 " },
-      'start syntax variation 3'     : { 'start': "END: abc123" },
-      'start syntax variation 4'     : { 'start': "END:abc123 " },
-      'start syntax variation 5'     : { 'start': "\tEND\t:\tabc123\t" },
-      'start escapes variation 1'    : { 'start': "END/" },
-      'start escapes variation 2'    : { 'start': "END/ts" },
-      'start escapes variation 3'    : { 'start': "END/tsrnL$" },
-      'start escapes variation 4'    : { 'start': "END / tsrnL$" },
-      'start escapes variation 5'    : { 'start': " END/ tsrnL$ " },
-      'start escapes variation 6'    : { 'start': " END/tsrnL$\t" },
-      'start escapes variation 7'    : { 'start': "\tEND\t/\ttsrnL$\t" },
-      'start everything variation 1' : { 'start': "\t  END   :  abc123foobar/\ttsrnL$   \t  " },
-      'start everything variation 2' : { 'start': "END:abc123foobar/tsrnL$" },
-
-      'end simple variation 1'  : { 'end': "END" },
-      'end simple variation 2'  : { 'end': "  END" },
-      'end simple variation 3'  : { 'end': "  END  ", "endTokenText": "  END" },
-      'end simple variation 4'  : { 'end': "END\t",   "endTokenText": "END" },
-      'end simple variation 5'  : { 'end': "|END" },
-      'end simple variation 6'  : { 'end': "|  END  ", "endTokenText": "|  END" },
-      'end simple variation 7'  : { 'end': "  |  \t END" },
-      'end simple variation 8'  : { 'end': "-END" },
-      'end simple variation 9'  : { 'end': "-  END  ", "endTokenText": "-  END" },
-      'end simple variation 10' : { 'end': "\t-  \t END" },
-      'end simple variation 11' : { 'end': "|-END" },
-      'end simple variation 12' : { 'end': "|-  END  ", "endTokenText": "|-  END" },
-      'end simple variation 13' : { 'end': "\t|-  \t END" },
-    }
-    for(var contextName in contexts) {
-      context(contextName, function() {
-        var start = contexts[contextName]['start']
-        var startTokenText = contexts[contextName]['startTokenText']
-        var end = contexts[contextName]['end']
-        var endTokenText = contexts[contextName]['endTokenText']
-        // A bit of magic, if the context doesn't define a start, just use 'END'
-        if (start === undefined) { start = 'END'; }
-        if (startTokenText === undefined) { startTokenText = "@(" + start + ")" }
-        if (end === undefined) { end = 'END'; }
-        if (endTokenText === undefined) { endTokenText = end }
-
-        it("tokenizes a " + contextName + " heredoc", function() {
-          var heredocStart = "@(" + start + ")"
-          var heredocEnd = end
-          var tokens = getLineTokens(grammar, "$foo = " + heredocStart + "\nText ${$foo} goes here\n" + end + "\n$foo = 'bar'");
-
-          // Expect that the heredoc is tokenized
-          expect(tokens[3]).to.eql({value: heredocStart, scopes: ['source.puppet', 'string.unquoted.heredoc.puppet', 'punctuation.definition.string.begin.puppet']});
-          expect(tokens[4]).to.eql({value: "\nText ${$foo} goes here\n", scopes: ['source.puppet', 'string.unquoted.heredoc.puppet']});
-          expect(tokens[5]).to.eql({value: endTokenText, scopes: ['source.puppet', 'string.unquoted.heredoc.puppet', 'punctuation.definition.string.end.puppet']});
-          // Expect that things after heredoc is tokenized
-          expect(tokens[7]).to.eql({value: "$", scopes: ['source.puppet', 'variable.other.readwrite.global.puppet', 'punctuation.definition.variable.puppet']});
-        });
-      });
-    };
-
-    context('negative tests', function() {
-      var contexts = {
-        'mismatched start end' : { 'start': "FOO", 'end': "BAR" },
-        'bad syntax'           : { 'start': "END: asd:123 /" },
-        'bad escapes'          : { 'start': "END/abc" },
-        'bad end marker'       : { 'end': "abc |- END" },
-      }
-      for(var contextName in contexts) {
-        context(contextName, function() {
-          var start = contexts[contextName]['start']
-          var startTokenText = contexts[contextName]['startTokenText']
-          var end = contexts[contextName]['end']
-          var endTokenText = contexts[contextName]['endTokenText']
-          // A bit of magic, if the context doesn't define a start, just use 'END'
-          if (start === undefined) { start = 'END'; }
-          if (startTokenText === undefined) { startTokenText = "@(" + start + ")" }
-          if (end === undefined) { end = 'END'; }
-          if (endTokenText === undefined) { endTokenText = end }
-
-          it("does not tokenizes a " + contextName + " heredoc", function() {
-            var heredocStart = "@(" + start + ")"
-            var heredocEnd = end
-            var tokens = getLineTokens(grammar, "$foo = " + heredocStart + "\nText goes here\n" + end + "\n$foo = 'bar'");
-
-            // Expect that the heredoc is not tokenized
-            expect(tokens[4]).to.not.eql({value: "\nText goes here\n", scopes: ['source.puppet', 'string.unquoted.heredoc.puppet']});
-            expect(tokens[5]).to.not.eql({value: endTokenText, scopes: ['source.puppet', 'string.unquoted.heredoc.puppet', 'punctuation.definition.string.end.puppet']});
-            // Expect that things after heredoc is not tokenized
-            expect(tokens[7]).to.not.eql({value: "$", scopes: ['source.puppet', 'variable.other.readwrite.global.puppet', 'punctuation.definition.variable.puppet']});
-            });
-        });
-      };
-    });
-  });
-
-  describe('interpolated heredoc', function() {
-    var contexts = {
-      'start simple variation 1'     : { 'start': '"END"' },
-      'start simple variation 2'     : { 'start': '  "END"' },
-      'start simple variation 3'     : { 'start': '"END"  ' },
-      'start simple variation 4'     : { 'start': '\t"END"  ' },
-      'start syntax variation 1'     : { 'start': '"END":abc123' },
-      'start syntax variation 2'     : { 'start': '"END": abc123 ' },
-      'start syntax variation 3'     : { 'start': '"END": abc123' },
-      'start syntax variation 4'     : { 'start': '"END":abc123 ' },
-      'start syntax variation 5'     : { 'start': '\t"END"\t:\tabc123\t' },
-      'start escapes variation 1'    : { 'start': '"END"/' },
-      'start escapes variation 2'    : { 'start': '"END"/ts' },
-      'start escapes variation 3'    : { 'start': '"END"/tsrnL$' },
-      'start escapes variation 4'    : { 'start': '"END" / tsrnL$' },
-      'start escapes variation 5'    : { 'start': ' "END"/ tsrnL$ ' },
-      'start escapes variation 6'    : { 'start': ' "END"/tsrnL$\t' },
-      'start escapes variation 7'    : { 'start': '\t"END"\t/\ttsrnL$\t' },
-      'start everything variation 1' : { 'start': '\t  "END"   :  abc123foobar/\ttsrnL$   \t  ' },
-      'start everything variation 2' : { 'start': '"END":abc123foobar/tsrnL$' },
-    }
-    for(var contextName in contexts) {
-      context(contextName, function() {
-        var start = contexts[contextName]['start']
-        var startTokenText = contexts[contextName]['startTokenText']
-        var end = contexts[contextName]['end']
-        var endTokenText = contexts[contextName]['endTokenText']
-        // A bit of magic, if the context doesn't define a start, just use 'END'
-        if (start === undefined) { start = 'END'; }
-        if (startTokenText === undefined) { startTokenText = "@(" + start + ")" }
-        if (end === undefined) { end = 'END'; }
-        if (endTokenText === undefined) { endTokenText = end }
-
-        it("tokenizes a " + contextName + " heredoc", function() {
-          var heredocStart = "@(" + start + ")"
-          var heredocEnd = end
-          var tokens = getLineTokens(grammar, "$foo = " + heredocStart + "\nText ${$foo} goes here\n" + end + "\n$foo = 'bar'");
-
-          // Expect that the heredoc is tokenized
-          expect(tokens[3]).to.eql({value: heredocStart, scopes: ['source.puppet', 'string.interpolated.heredoc.puppet', 'punctuation.definition.string.begin.puppet']});
-          // Expect that interpolated strings tokenized
-          expect(tokens[5]).to.eql({value: "${", scopes: ['source.puppet', 'string.interpolated.heredoc.puppet', 'meta.embedded.line.puppet', 'punctuation.section.embedded.begin.puppet']});
-          // Expect that the heredoc end marker is tokenized
-          expect(tokens[10]).to.eql({value: endTokenText, scopes: ['source.puppet', 'string.interpolated.heredoc.puppet', 'punctuation.definition.string.end.puppet']});
-          // Expect that things after heredoc is tokenized
-          expect(tokens[12]).to.eql({value: "$", scopes: ['source.puppet', 'variable.other.readwrite.global.puppet', 'punctuation.definition.variable.puppet']});
-        });
-      });
-    };
-
-    context('negative tests', function() {
-      var contexts = {
-        'mismatched start end' : { 'start': '"FOO"', 'end': 'BAR' },
-        'bad syntax'           : { 'start': '"END": asd:123 /' },
-        'bad escapes'          : { 'start': '"END"/abc' },
-        'bad end marker'       : { 'end': 'abc |- END' },
-      }
-      for(var contextName in contexts) {
-        context(contextName, function() {
-          var start = contexts[contextName]['start']
-          var startTokenText = contexts[contextName]['startTokenText']
-          var end = contexts[contextName]['end']
-          var endTokenText = contexts[contextName]['endTokenText']
-          // A bit of magic, if the context doesn't define a start, just use 'END'
-          if (start === undefined) { start = 'END'; }
-          if (startTokenText === undefined) { startTokenText = "@(" + start + ")" }
-          if (end === undefined) { end = 'END'; }
-          if (endTokenText === undefined) { endTokenText = end }
-
-          it("does not tokenizes a " + contextName + " heredoc", function() {
-            var heredocStart = "@(" + start + ")"
-            var heredocEnd = end
-            var tokens = getLineTokens(grammar, "$foo = " + heredocStart + "\nText goes here\n" + end + "\n$foo = 'bar'");
-
-            // Expect that the heredoc is not tokenized
-            expect(tokens[5]).to.not.eql({value: endTokenText, scopes: ['source.puppet', 'string.interpolated.heredoc.puppet', 'punctuation.definition.string.end.puppet']});
-          });
-        });
-      };
-    });
-  });
-
-
-
 });


### PR DESCRIPTION
Fixes #30 

Previously predefined variables were not highlight correctly as they were not
considered valid variable names according the to regex to detect them.  This
commit:

* Adds a "predefined" kind of variable, specifically for regex match groups
  (`\d+`)

* Adds tests for these as resource names, basic variable assignment and within
  interpolated strings

* Applies same changes to other generated syntax files

---

Reminder

- [x] Added Tests

- [x] Ran `npm run convert` and committed the changes too
