### PR TITLE
(GH-32)(GH-37) Highlight resource names and titles correctly

### DIFF
--- a/generated-syntaxes/puppet.tmLanguage.atom.cson
+++ b/generated-syntaxes/puppet.tmLanguage.atom.cson
@@ -455,7 +455,7 @@
         'include': '#numbers'
       }
       {
-        'include': '#variables'
+        'include': '#variable'
       }
       {
         'include': '#hash'
@@ -484,6 +484,9 @@
         'name': 'punctuation.definition.array.end.puppet'
     'name': 'meta.array.puppet'
     'patterns': [
+      {
+        'match': '\\s*,\\s*'
+      }
       {
         'include': '#parameter-default-types'
       }

--- a/generated-syntaxes/puppet.tmLanguage.atom.cson
+++ b/generated-syntaxes/puppet.tmLanguage.atom.cson
@@ -164,31 +164,7 @@
     ]
   }
   {
-    'captures':
-      '1':
-        'name': 'storage.type.puppet'
-      '2':
-        'name': 'entity.name.section.puppet'
-    'match': '^\\s*(\\w+)\\s*{\\s*([\'"].+[\'"]):'
-    'name': 'meta.definition.resource.puppet'
-  }
-  {
-    'match': '^\\s*(\\w+)\\s*{\\s*(\\$[a-zA-Z_]+)\\s*:'
-    'captures':
-      '1':
-        'name': 'storage.type.puppet'
-      '2':
-        'name': 'entity.name.section.puppet'
-    'name': 'meta.definition.resource.puppet'
-  }
-  {
-    'match': '^\\s*(\\w+)\\s*{\\s*(\\$(\\d+))\\s*:'
-    'captures':
-      '1':
-        'name': 'storage.type.puppet'
-      '2':
-        'name': 'entity.name.section.puppet'
-    'name': 'meta.definition.resource.puppet'
+    'include': '#resource-definition'
   }
   {
     'match': '\\b(case|if|else|elsif|unless)(?!::)\\b'
@@ -574,6 +550,24 @@
         'comment': 'FLOAT [(+|-)] digits . digits [e [(+|-)] digits]'
         'match': '(?<!\\w)([-+]?)\\d+\\.\\d+(?i:e(\\+|-){0,1}\\d+){0,1}(?!\\w|\\d)'
         'name': 'constant.numeric.integer.puppet'
+      }
+    ]
+  'resource-definition':
+    'begin': '^\\s*((?#Bareword Resource Name)[a-z][a-z0-9_]*|(?#Qualified Resource Name)(?:[a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)+)\\s*({)\\s*'
+    'beginCaptures':
+      '1':
+        'name': 'meta.definition.resource.puppet storage.type.puppet'
+    'end': ':'
+    'contentName': 'entity.name.section.puppet'
+    'patterns': [
+      {
+        'include': '#strings'
+      }
+      {
+        'include': '#variable'
+      }
+      {
+        'include': '#array'
       }
     ]
   'variable':

--- a/generated-syntaxes/puppet.tmLanguage.cson
+++ b/generated-syntaxes/puppet.tmLanguage.cson
@@ -455,7 +455,7 @@ repository:
         include: "#numbers"
       }
       {
-        include: "#variables"
+        include: "#variable"
       }
       {
         include: "#hash"
@@ -484,6 +484,9 @@ repository:
         name: "punctuation.definition.array.end.puppet"
     name: "meta.array.puppet"
     patterns: [
+      {
+        match: "\\s*,\\s*"
+      }
       {
         include: "#parameter-default-types"
       }

--- a/generated-syntaxes/puppet.tmLanguage.cson
+++ b/generated-syntaxes/puppet.tmLanguage.cson
@@ -164,31 +164,7 @@ patterns: [
     ]
   }
   {
-    captures:
-      "1":
-        name: "storage.type.puppet"
-      "2":
-        name: "entity.name.section.puppet"
-    match: "^\\s*(\\w+)\\s*{\\s*([\\'\"].+[\\'\"]):"
-    name: "meta.definition.resource.puppet"
-  }
-  {
-    match: "^\\s*(\\w+)\\s*{\\s*(\\$[a-zA-Z_]+)\\s*:"
-    captures:
-      "1":
-        name: "storage.type.puppet"
-      "2":
-        name: "entity.name.section.puppet"
-    name: "meta.definition.resource.puppet"
-  }
-  {
-    match: "^\\s*(\\w+)\\s*{\\s*(\\$(\\d+))\\s*:"
-    captures:
-      "1":
-        name: "storage.type.puppet"
-      "2":
-        name: "entity.name.section.puppet"
-    name: "meta.definition.resource.puppet"
+    include: "#resource-definition"
   }
   {
     match: "\\b(case|if|else|elsif|unless)(?!::)\\b"
@@ -574,6 +550,24 @@ repository:
         comment: "FLOAT [(+|-)] digits . digits [e [(+|-)] digits]"
         match: "(?<!\\w)([-+]?)\\d+\\.\\d+(?i:e(\\+|-){0,1}\\d+){0,1}(?!\\w|\\d)"
         name: "constant.numeric.integer.puppet"
+      }
+    ]
+  "resource-definition":
+    begin: "^\\s*((?#Bareword Resource Name)[a-z][a-z0-9_]*|(?#Qualified Resource Name)(?:[a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)+)\\s*({)\\s*"
+    beginCaptures:
+      "1":
+        name: "meta.definition.resource.puppet storage.type.puppet"
+    end: ":"
+    contentName: "entity.name.section.puppet"
+    patterns: [
+      {
+        include: "#strings"
+      }
+      {
+        include: "#variable"
+      }
+      {
+        include: "#array"
       }
     ]
   variable:

--- a/generated-syntaxes/puppet.tmLanguage.json
+++ b/generated-syntaxes/puppet.tmLanguage.json
@@ -544,7 +544,7 @@
           "include": "#numbers"
         },
         {
-          "include": "#variables"
+          "include": "#variable"
         },
         {
           "include": "#hash"
@@ -578,6 +578,9 @@
       },
       "name": "meta.array.puppet",
       "patterns": [
+        {
+          "match": "\\s*,\\s*"
+        },
         {
           "include": "#parameter-default-types"
         },

--- a/generated-syntaxes/puppet.tmLanguage.json
+++ b/generated-syntaxes/puppet.tmLanguage.json
@@ -200,40 +200,7 @@
       ]
     },
     {
-      "captures": {
-        "1": {
-          "name": "storage.type.puppet"
-        },
-        "2": {
-          "name": "entity.name.section.puppet"
-        }
-      },
-      "match": "^\\s*(\\w+)\\s*{\\s*([\\'\"].+[\\'\"]):",
-      "name": "meta.definition.resource.puppet"
-    },
-    {
-      "match": "^\\s*(\\w+)\\s*{\\s*(\\$[a-zA-Z_]+)\\s*:",
-      "captures": {
-        "1": {
-          "name": "storage.type.puppet"
-        },
-        "2": {
-          "name": "entity.name.section.puppet"
-        }
-      },
-      "name": "meta.definition.resource.puppet"
-    },
-    {
-      "match": "^\\s*(\\w+)\\s*{\\s*(\\$(\\d+))\\s*:",
-      "captures": {
-        "1": {
-          "name": "storage.type.puppet"
-        },
-        "2": {
-          "name": "entity.name.section.puppet"
-        }
-      },
-      "name": "meta.definition.resource.puppet"
+      "include": "#resource-definition"
     },
     {
       "match": "\\b(case|if|else|elsif|unless)(?!::)\\b",
@@ -689,6 +656,27 @@
           "comment": "FLOAT [(+|-)] digits . digits [e [(+|-)] digits]",
           "match": "(?<!\\w)([-+]?)\\d+\\.\\d+(?i:e(\\+|-){0,1}\\d+){0,1}(?!\\w|\\d)",
           "name": "constant.numeric.integer.puppet"
+        }
+      ]
+    },
+    "resource-definition": {
+      "begin": "^\\s*((?#Bareword Resource Name)[a-z][a-z0-9_]*|(?#Qualified Resource Name)(?:[a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)+)\\s*({)\\s*",
+      "beginCaptures": {
+        "1": {
+          "name": "meta.definition.resource.puppet storage.type.puppet"
+        }
+      },
+      "end": ":",
+      "contentName": "entity.name.section.puppet",
+      "patterns": [
+        {
+          "include": "#strings"
+        },
+        {
+          "include": "#variable"
+        },
+        {
+          "include": "#array"
         }
       ]
     },

--- a/generated-syntaxes/puppet.tmLanguage.yaml
+++ b/generated-syntaxes/puppet.tmLanguage.yaml
@@ -295,7 +295,7 @@ repository:
     patterns:
       - include: '#strings'
       - include: '#numbers'
-      - include: '#variables'
+      - include: '#variable'
       - include: '#hash'
       - include: '#array'
       - include: '#function_call'
@@ -312,6 +312,7 @@ repository:
         name: punctuation.definition.array.end.puppet
     name: meta.array.puppet
     patterns:
+      - match: '\s*,\s*'
       - include: '#parameter-default-types'
       - include: '#line_comment'
   hash:

--- a/generated-syntaxes/puppet.tmLanguage.yaml
+++ b/generated-syntaxes/puppet.tmLanguage.yaml
@@ -113,27 +113,7 @@ patterns:
         name: meta.function.argument.default.puppet
         patterns:
           - include: '#parameter-default-types'
-  - captures:
-      '1':
-        name: storage.type.puppet
-      '2':
-        name: entity.name.section.puppet
-    match: '^\s*(\w+)\s*{\s*([\''"].+[\''"]):'
-    name: meta.definition.resource.puppet
-  - match: '^\s*(\w+)\s*{\s*(\$[a-zA-Z_]+)\s*:'
-    captures:
-      '1':
-        name: storage.type.puppet
-      '2':
-        name: entity.name.section.puppet
-    name: meta.definition.resource.puppet
-  - match: '^\s*(\w+)\s*{\s*(\$(\d+))\s*:'
-    captures:
-      '1':
-        name: storage.type.puppet
-      '2':
-        name: entity.name.section.puppet
-    name: meta.definition.resource.puppet
+  - include: '#resource-definition'
   - match: '\b(case|if|else|elsif|unless)(?!::)\b'
     name: keyword.control.puppet
   - include: '#heredoc'
@@ -375,6 +355,17 @@ repository:
       - comment: 'FLOAT [(+|-)] digits . digits [e [(+|-)] digits]'
         match: '(?<!\w)([-+]?)\d+\.\d+(?i:e(\+|-){0,1}\d+){0,1}(?!\w|\d)'
         name: constant.numeric.integer.puppet
+  resource-definition:
+    begin: '^\s*((?#Bareword Resource Name)[a-z][a-z0-9_]*|(?#Qualified Resource Name)(?:[a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)+)\s*({)\s*'
+    beginCaptures:
+      '1':
+        name: meta.definition.resource.puppet storage.type.puppet
+    end: ':'
+    contentName: entity.name.section.puppet
+    patterns:
+      - include: '#strings'
+      - include: '#variable'
+      - include: '#array'
   variable:
     patterns:
       - match: (\$)(\d+)

--- a/syntaxes/puppet.tmLanguage
+++ b/syntaxes/puppet.tmLanguage
@@ -856,7 +856,7 @@
         </dict>
         <dict>
           <key>include</key>
-          <string>#variables</string>
+          <string>#variable</string>
         </dict>
         <dict>
           <key>include</key>
@@ -907,6 +907,10 @@
       <string>meta.array.puppet</string>
       <key>patterns</key>
       <array>
+        <dict>
+          <key>match</key>
+          <string>\s*,\s*</string>
+        </dict>
         <dict>
           <key>include</key>
           <string>#parameter-default-types</string>

--- a/syntaxes/puppet.tmLanguage
+++ b/syntaxes/puppet.tmLanguage
@@ -321,65 +321,9 @@
         </dict>
       </array>
     </dict>
-    <!-- Resource definition using a string based name -->
     <dict>
-      <key>captures</key>
-      <dict>
-        <key>1</key>
-        <dict>
-          <key>name</key>
-          <string>storage.type.puppet</string>
-        </dict>
-        <key>2</key>
-        <dict>
-          <key>name</key>
-          <string>entity.name.section.puppet</string>
-        </dict>
-      </dict>
-      <key>match</key>
-      <string>^\s*(\w+)\s*{\s*([\'"].+[\'"]):</string>
-      <key>name</key>
-      <string>meta.definition.resource.puppet</string>
-    </dict>
-    <!-- Resource definition using a user variable name -->
-    <dict>
-      <key>match</key>
-      <string>^\s*(\w+)\s*{\s*(\$[a-zA-Z_]+)\s*:</string>
-      <key>captures</key>
-      <dict>
-        <key>1</key>
-        <dict>
-          <key>name</key>
-          <string>storage.type.puppet</string>
-        </dict>
-        <key>2</key>
-        <dict>
-          <key>name</key>
-          <string>entity.name.section.puppet</string>
-        </dict>
-      </dict>
-      <key>name</key>
-      <string>meta.definition.resource.puppet</string>
-    </dict>
-    <!-- Resource definition using a predefined name -->
-    <dict>
-      <key>match</key>
-      <string>^\s*(\w+)\s*{\s*(\$(\d+))\s*:</string>
-      <key>captures</key>
-      <dict>
-        <key>1</key>
-        <dict>
-          <key>name</key>
-          <string>storage.type.puppet</string>
-        </dict>
-        <key>2</key>
-        <dict>
-          <key>name</key>
-          <string>entity.name.section.puppet</string>
-        </dict>
-      </dict>
-      <key>name</key>
-      <string>meta.definition.resource.puppet</string>
+      <key>include</key>
+      <string>#resource-definition</string>
     </dict>
     <dict>
       <key>match</key>
@@ -1088,6 +1032,41 @@
           <string>(?&lt;!\w)([-+]?)\d+\.\d+(?i:e(\+|-){0,1}\d+){0,1}(?!\w|\d)</string>
           <key>name</key>
           <string>constant.numeric.integer.puppet</string>
+        </dict>
+      </array>
+    </dict>
+    <!-- Resource definition using a bareword of qualified resource name -->
+    <!-- Reference https://puppet.com/docs/puppet/latest/lang_reserved.html#classes-and-defined-resource-types -->
+    <key>resource-definition</key>
+    <dict>
+      <key>begin</key>
+      <string>^\s*((?#Bareword Resource Name)[a-z][a-z0-9_]*|(?#Qualified Resource Name)(?:[a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)+)\s*({)\s*</string>
+      <key>beginCaptures</key>
+      <dict>
+        <key>1</key>
+        <dict>
+          <key>name</key>
+          <string>meta.definition.resource.puppet storage.type.puppet</string>
+        </dict>
+      </dict>
+      <key>end</key>
+      <string>:</string>
+      <key>contentName</key>
+      <string>entity.name.section.puppet</string>
+      <!-- Resource title matching patterns -->
+      <key>patterns</key>
+      <array>
+        <dict>
+          <key>include</key>
+          <string>#strings</string>
+        </dict>
+        <dict>
+          <key>include</key>
+          <string>#variable</string>
+        </dict>
+        <dict>
+          <key>include</key>
+          <string>#array</string>
         </dict>
       </array>
     </dict>

--- a/tests/syntaxes/puppet.tmLanguage.js
+++ b/tests/syntaxes/puppet.tmLanguage.js
@@ -125,6 +125,32 @@ describe('puppet.tmLanguage', function() {
       expect(tokens[8]).to.eql({value: '#', scopes: ['source.puppet', 'entity.name.section.puppet', 'meta.array.puppet', 'comment.line.number-sign.puppet', 'punctuation.definition.comment.puppet']});
       expect(tokens[9]).to.eql({value: ' This is a comment\n', scopes: ['source.puppet', 'entity.name.section.puppet', 'meta.array.puppet', 'comment.line.number-sign.puppet']});
     });
+
+    var contexts = {
+      'single quoted string': { 'testcase': "'foo'",           'expectedText': 'foo',      'tokenIndex1': 5, 'tokenIndex2':9,  'scopesSuffix': ['string.quoted.single.puppet'] },
+      'double quoted string': { 'testcase': "\"foo\"",         'expectedText': 'foo',      'tokenIndex1': 5, 'tokenIndex2':9,  'scopesSuffix': ['string.quoted.double.interpolated.puppet'] },
+      'integer':              { 'testcase': "123",             'expectedText': '123',      'tokenIndex1': 4, 'tokenIndex2':6,  'scopesSuffix': ['constant.numeric.integer.puppet'] },
+      'variable':             { 'testcase': "$foo::bar",       'expectedText': 'foo::bar', 'tokenIndex1': 5, 'tokenIndex2':8,  'scopesSuffix': ['variable.other.readwrite.global.puppet'] },
+      'array':                { 'testcase': "['abc']",         'expectedText': 'abc',      'tokenIndex1': 6, 'tokenIndex2':12, 'scopesSuffix': ['meta.array.puppet', 'string.quoted.single.puppet'] },
+      'hash':                 { 'testcase': "{'abc' => 123 }", 'expectedText': 'abc',      'tokenIndex1': 6, 'tokenIndex2':15, 'scopesSuffix': ['meta.hash.puppet', 'string.quoted.single.puppet'] },
+    }
+    for(var contextName in contexts) {
+      context(contextName, function() {
+        var testcase = contexts[contextName]['testcase'];
+        var expectedText = contexts[contextName]['expectedText'];
+        var scopesSuffix = contexts[contextName]['scopesSuffix'];
+        var tokenIndex1 = contexts[contextName]['tokenIndex1'];
+        var tokenIndex2 = contexts[contextName]['tokenIndex2'];
+
+        it("tokenizes " + contextName + " items within the array", function() {
+          // We add the item twice here to make sure it tokenises with a comma delimiting it
+          var tokens = getLineTokens(grammar, "$x = [" + testcase + " , " + testcase + "]")
+
+          expect(tokens[tokenIndex1]).to.eql({value: expectedText, scopes: ['source.puppet', 'meta.array.puppet'].concat(scopesSuffix)});
+          expect(tokens[tokenIndex2]).to.eql({value: expectedText, scopes: ['source.puppet', 'meta.array.puppet'].concat(scopesSuffix)});
+        });
+      });
+    };
   });
 
   describe('puppet tasks and plans', function() {


### PR DESCRIPTION
Fixes #32 
Fixes #37

Previously the syntax highlighting of resource names did not handle fully
qualified names (foo::bar), nor did it highlight the resource title correctly.
All titles were just an entity.name token, which meant that strings, variables
all looked the same, instead of being tokenised correctly for what they were.

This commit:
* Uses bareword and qualified name regexes for the resource name detection
* Changes the regex matching to be begin-end pairs instead of a plain match.
  This meant the resource title could be tokenised separately and then be
  highlighted appropriately
* Tests were added for the different kinds of resource names

---

Reminder

- [x] Added Tests

- [x] Ran `npm run convert` and committed the changes too
