### PR TITLE
(GH-38)(GH-39) Fix tokenising of class, plan, node, define and include statements

### DIFF
--- a/generated-syntaxes/puppet.tmLanguage.atom.cson
+++ b/generated-syntaxes/puppet.tmLanguage.atom.cson
@@ -18,7 +18,19 @@
     'name': 'comment.block.puppet'
   }
   {
-    'begin': '\\b(node|class)\\s+((?:[-_A-Za-z0-9"\'.]+::)*[-_A-Za-z0-9"\'.]+)\\s*'
+    'begin': '\\b(node)\\s+(\\"[^\\"]+\\"|\'[^\']+\')\\s*'
+    'captures':
+      '1':
+        'name': 'storage.type.puppet'
+      '2':
+        'name': 'entity.name.type.class.puppet'
+    'end': '(?={)'
+    'name': 'meta.definition.class.puppet'
+    'patterns': [
+    ]
+  }
+  {
+    'begin': '\\b(class)\\s+((?#Qualified Resource Name)(?:[a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)+|(?#Bareword Resource Name)[a-z][a-z0-9_]*)\\s*'
     'captures':
       '1':
         'name': 'storage.type.puppet'
@@ -45,30 +57,7 @@
         'include': '#line_comment'
       }
       {
-        'captures':
-          '1':
-            'name': 'variable.other.puppet'
-          '2':
-            'name': 'punctuation.definition.variable.puppet'
-        'match': '((\\$+)[a-zA-Z_][a-zA-Z0-9_]*)\\s*(?=,|\\))'
-        'name': 'meta.function.argument.puppet'
-      }
-      {
-        'begin': '((\\$+)[a-zA-Z_][a-zA-Z0-9_]*)(?:\\s*(=)\\s*)\\s*'
-        'captures':
-          '1':
-            'name': 'variable.other.puppet'
-          '2':
-            'name': 'punctuation.definition.variable.puppet'
-          '3':
-            'name': 'keyword.operator.assignment.puppet'
-        'end': '(?=,|\\))'
-        'name': 'meta.function.argument.puppet'
-        'patterns': [
-          {
-            'include': '#parameter-default-types'
-          }
-        ]
+        'include': '#resource-parameters'
       }
       {
         'include': '#parameter-default-types'
@@ -76,7 +65,7 @@
     ]
   }
   {
-    'begin': '^\\s*(plan)\\s+((?:[a-z][a-z0-9_]+::)*[a-z][a-z0-9_]+)\\s*'
+    'begin': '^\\s*(plan)\\s+((?#Qualified Resource Name)(?:[a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)+|(?#Bareword Resource Name)[a-z][a-z0-9_]*)\\s*'
     'captures':
       '1':
         'name': 'storage.type.puppet'
@@ -89,30 +78,7 @@
         'include': '#line_comment'
       }
       {
-        'captures':
-          '1':
-            'name': 'variable.other.puppet'
-          '2':
-            'name': 'punctuation.definition.variable.puppet'
-        'match': '((\\$+)[a-zA-Z_][a-zA-Z0-9_]*)\\s*(?=,|\\))'
-        'name': 'meta.function.argument.puppet'
-      }
-      {
-        'begin': '((\\$+)[a-zA-Z_][a-zA-Z0-9_]*)(?:\\s*(=)\\s*)\\s*'
-        'captures':
-          '1':
-            'name': 'variable.other.puppet'
-          '2':
-            'name': 'punctuation.definition.variable.puppet'
-          '3':
-            'name': 'keyword.operator.assignment.puppet'
-        'end': '(?=,|\\))'
-        'name': 'meta.function.argument.puppet'
-        'patterns': [
-          {
-            'include': '#parameter-default-types'
-          }
-        ]
+        'include': '#resource-parameters'
       }
       {
         'include': '#parameter-default-types'
@@ -120,46 +86,23 @@
     ]
   }
   {
-    'begin': '^\\s*(define|function)\\s+([a-zA-Z0-9_:]+)\\s*(\\()'
-    'beginCaptures':
+    'begin': '^\\s*(define|function)\\s+((?#Bareword Resource Name)[a-z][a-z0-9_]*|(?#Qualified Resource Name)(?:[a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)+)\\s*(\\()'
+    'captures':
       '1':
         'name': 'storage.type.function.puppet'
       '2':
         'name': 'entity.name.function.puppet'
-      '3':
-        'name': 'punctuation.definition.parameters.begin.puppet'
-    'contentName': 'meta.function.arguments.puppet'
-    'end': '\\)'
-    'endCaptures':
-      '1':
-        'name': 'punctuation.definition.parameters.end.puppet'
+    'end': '(?={)'
     'name': 'meta.function.puppet'
     'patterns': [
       {
-        'captures':
-          '1':
-            'name': 'variable.other.puppet'
-          '2':
-            'name': 'punctuation.definition.variable.puppet'
-        'match': '((\\$+)[a-zA-Z_][a-zA-Z0-9_]*)\\s*(?=,|\\))'
-        'name': 'meta.function.argument.no-default.puppet'
+        'include': '#line_comment'
       }
       {
-        'begin': '((\\$+)[a-zA-Z_][a-zA-Z0-9_]*)(?:\\s*(=)\\s*)\\s*'
-        'captures':
-          '1':
-            'name': 'variable.other.puppet'
-          '2':
-            'name': 'punctuation.definition.variable.puppet'
-          '3':
-            'name': 'keyword.operator.assignment.puppet'
-        'end': '(?=,|\\))'
-        'name': 'meta.function.argument.default.puppet'
-        'patterns': [
-          {
-            'include': '#parameter-default-types'
-          }
-        ]
+        'include': '#resource-parameters'
+      }
+      {
+        'include': '#parameter-default-types'
       }
     ]
   }
@@ -198,6 +141,7 @@
       '1':
         'name': 'keyword.control.import.include.puppet'
     'end': '(?=\\s|$)'
+    'contentName': 'variable.parameter.include.puppet'
     'name': 'meta.include.puppet'
   }
   {
@@ -471,6 +415,35 @@
       }
       {
         'include': '#puppet-datatypes'
+      }
+    ]
+  'resource-parameters':
+    'patterns': [
+      {
+        'captures':
+          '1':
+            'name': 'variable.other.puppet'
+          '2':
+            'name': 'punctuation.definition.variable.puppet'
+        'match': '((\\$+)[a-zA-Z_][a-zA-Z0-9_]*)\\s*(?=,|\\))'
+        'name': 'meta.function.argument.puppet'
+      }
+      {
+        'begin': '((\\$+)[a-zA-Z_][a-zA-Z0-9_]*)(?:\\s*(=)\\s*)\\s*'
+        'captures':
+          '1':
+            'name': 'variable.other.puppet'
+          '2':
+            'name': 'punctuation.definition.variable.puppet'
+          '3':
+            'name': 'keyword.operator.assignment.puppet'
+        'end': '(?=,|\\))'
+        'name': 'meta.function.argument.puppet'
+        'patterns': [
+          {
+            'include': '#parameter-default-types'
+          }
+        ]
       }
     ]
   'array':

--- a/generated-syntaxes/puppet.tmLanguage.cson
+++ b/generated-syntaxes/puppet.tmLanguage.cson
@@ -18,7 +18,18 @@ patterns: [
     name: "comment.block.puppet"
   }
   {
-    begin: "\\b(node|class)\\s+((?:[-_A-Za-z0-9\"\\'.]+::)*[-_A-Za-z0-9\"\\'.]+)\\s*"
+    begin: "\\b(node)\\s+(\\\"[^\\\"]+\\\"|\\'[^\\']+\\')\\s*"
+    captures:
+      "1":
+        name: "storage.type.puppet"
+      "2":
+        name: "entity.name.type.class.puppet"
+    end: "(?={)"
+    name: "meta.definition.class.puppet"
+    patterns: []
+  }
+  {
+    begin: "\\b(class)\\s+((?#Qualified Resource Name)(?:[a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)+|(?#Bareword Resource Name)[a-z][a-z0-9_]*)\\s*"
     captures:
       "1":
         name: "storage.type.puppet"
@@ -45,30 +56,7 @@ patterns: [
         include: "#line_comment"
       }
       {
-        captures:
-          "1":
-            name: "variable.other.puppet"
-          "2":
-            name: "punctuation.definition.variable.puppet"
-        match: "((\\$+)[a-zA-Z_][a-zA-Z0-9_]*)\\s*(?=,|\\))"
-        name: "meta.function.argument.puppet"
-      }
-      {
-        begin: "((\\$+)[a-zA-Z_][a-zA-Z0-9_]*)(?:\\s*(=)\\s*)\\s*"
-        captures:
-          "1":
-            name: "variable.other.puppet"
-          "2":
-            name: "punctuation.definition.variable.puppet"
-          "3":
-            name: "keyword.operator.assignment.puppet"
-        end: "(?=,|\\))"
-        name: "meta.function.argument.puppet"
-        patterns: [
-          {
-            include: "#parameter-default-types"
-          }
-        ]
+        include: "#resource-parameters"
       }
       {
         include: "#parameter-default-types"
@@ -76,7 +64,7 @@ patterns: [
     ]
   }
   {
-    begin: "^\\s*(plan)\\s+((?:[a-z][a-z0-9_]+::)*[a-z][a-z0-9_]+)\\s*"
+    begin: "^\\s*(plan)\\s+((?#Qualified Resource Name)(?:[a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)+|(?#Bareword Resource Name)[a-z][a-z0-9_]*)\\s*"
     captures:
       "1":
         name: "storage.type.puppet"
@@ -89,30 +77,7 @@ patterns: [
         include: "#line_comment"
       }
       {
-        captures:
-          "1":
-            name: "variable.other.puppet"
-          "2":
-            name: "punctuation.definition.variable.puppet"
-        match: "((\\$+)[a-zA-Z_][a-zA-Z0-9_]*)\\s*(?=,|\\))"
-        name: "meta.function.argument.puppet"
-      }
-      {
-        begin: "((\\$+)[a-zA-Z_][a-zA-Z0-9_]*)(?:\\s*(=)\\s*)\\s*"
-        captures:
-          "1":
-            name: "variable.other.puppet"
-          "2":
-            name: "punctuation.definition.variable.puppet"
-          "3":
-            name: "keyword.operator.assignment.puppet"
-        end: "(?=,|\\))"
-        name: "meta.function.argument.puppet"
-        patterns: [
-          {
-            include: "#parameter-default-types"
-          }
-        ]
+        include: "#resource-parameters"
       }
       {
         include: "#parameter-default-types"
@@ -120,46 +85,23 @@ patterns: [
     ]
   }
   {
-    begin: "^\\s*(define|function)\\s+([a-zA-Z0-9_:]+)\\s*(\\()"
-    beginCaptures:
+    begin: "^\\s*(define|function)\\s+((?#Bareword Resource Name)[a-z][a-z0-9_]*|(?#Qualified Resource Name)(?:[a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)+)\\s*(\\()"
+    captures:
       "1":
         name: "storage.type.function.puppet"
       "2":
         name: "entity.name.function.puppet"
-      "3":
-        name: "punctuation.definition.parameters.begin.puppet"
-    contentName: "meta.function.arguments.puppet"
-    end: "\\)"
-    endCaptures:
-      "1":
-        name: "punctuation.definition.parameters.end.puppet"
+    end: "(?={)"
     name: "meta.function.puppet"
     patterns: [
       {
-        captures:
-          "1":
-            name: "variable.other.puppet"
-          "2":
-            name: "punctuation.definition.variable.puppet"
-        match: "((\\$+)[a-zA-Z_][a-zA-Z0-9_]*)\\s*(?=,|\\))"
-        name: "meta.function.argument.no-default.puppet"
+        include: "#line_comment"
       }
       {
-        begin: "((\\$+)[a-zA-Z_][a-zA-Z0-9_]*)(?:\\s*(=)\\s*)\\s*"
-        captures:
-          "1":
-            name: "variable.other.puppet"
-          "2":
-            name: "punctuation.definition.variable.puppet"
-          "3":
-            name: "keyword.operator.assignment.puppet"
-        end: "(?=,|\\))"
-        name: "meta.function.argument.default.puppet"
-        patterns: [
-          {
-            include: "#parameter-default-types"
-          }
-        ]
+        include: "#resource-parameters"
+      }
+      {
+        include: "#parameter-default-types"
       }
     ]
   }
@@ -198,6 +140,7 @@ patterns: [
       "1":
         name: "keyword.control.import.include.puppet"
     end: "(?=\\s|$)"
+    contentName: "variable.parameter.include.puppet"
     name: "meta.include.puppet"
   }
   {
@@ -471,6 +414,35 @@ repository:
       }
       {
         include: "#puppet-datatypes"
+      }
+    ]
+  "resource-parameters":
+    patterns: [
+      {
+        captures:
+          "1":
+            name: "variable.other.puppet"
+          "2":
+            name: "punctuation.definition.variable.puppet"
+        match: "((\\$+)[a-zA-Z_][a-zA-Z0-9_]*)\\s*(?=,|\\))"
+        name: "meta.function.argument.puppet"
+      }
+      {
+        begin: "((\\$+)[a-zA-Z_][a-zA-Z0-9_]*)(?:\\s*(=)\\s*)\\s*"
+        captures:
+          "1":
+            name: "variable.other.puppet"
+          "2":
+            name: "punctuation.definition.variable.puppet"
+          "3":
+            name: "keyword.operator.assignment.puppet"
+        end: "(?=,|\\))"
+        name: "meta.function.argument.puppet"
+        patterns: [
+          {
+            include: "#parameter-default-types"
+          }
+        ]
       }
     ]
   array:

--- a/generated-syntaxes/puppet.tmLanguage.json
+++ b/generated-syntaxes/puppet.tmLanguage.json
@@ -19,7 +19,21 @@
       "name": "comment.block.puppet"
     },
     {
-      "begin": "\\b(node|class)\\s+((?:[-_A-Za-z0-9\"\\'.]+::)*[-_A-Za-z0-9\"\\'.]+)\\s*",
+      "begin": "\\b(node)\\s+(\\\"[^\\\"]+\\\"|\\'[^\\']+\\')\\s*",
+      "captures": {
+        "1": {
+          "name": "storage.type.puppet"
+        },
+        "2": {
+          "name": "entity.name.type.class.puppet"
+        }
+      },
+      "end": "(?={)",
+      "name": "meta.definition.class.puppet",
+      "patterns": []
+    },
+    {
+      "begin": "\\b(class)\\s+((?#Qualified Resource Name)(?:[a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)+|(?#Bareword Resource Name)[a-z][a-z0-9_]*)\\s*",
       "captures": {
         "1": {
           "name": "storage.type.puppet"
@@ -51,37 +65,7 @@
           "include": "#line_comment"
         },
         {
-          "captures": {
-            "1": {
-              "name": "variable.other.puppet"
-            },
-            "2": {
-              "name": "punctuation.definition.variable.puppet"
-            }
-          },
-          "match": "((\\$+)[a-zA-Z_][a-zA-Z0-9_]*)\\s*(?=,|\\))",
-          "name": "meta.function.argument.puppet"
-        },
-        {
-          "begin": "((\\$+)[a-zA-Z_][a-zA-Z0-9_]*)(?:\\s*(=)\\s*)\\s*",
-          "captures": {
-            "1": {
-              "name": "variable.other.puppet"
-            },
-            "2": {
-              "name": "punctuation.definition.variable.puppet"
-            },
-            "3": {
-              "name": "keyword.operator.assignment.puppet"
-            }
-          },
-          "end": "(?=,|\\))",
-          "name": "meta.function.argument.puppet",
-          "patterns": [
-            {
-              "include": "#parameter-default-types"
-            }
-          ]
+          "include": "#resource-parameters"
         },
         {
           "include": "#parameter-default-types"
@@ -89,7 +73,7 @@
       ]
     },
     {
-      "begin": "^\\s*(plan)\\s+((?:[a-z][a-z0-9_]+::)*[a-z][a-z0-9_]+)\\s*",
+      "begin": "^\\s*(plan)\\s+((?#Qualified Resource Name)(?:[a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)+|(?#Bareword Resource Name)[a-z][a-z0-9_]*)\\s*",
       "captures": {
         "1": {
           "name": "storage.type.puppet"
@@ -105,37 +89,7 @@
           "include": "#line_comment"
         },
         {
-          "captures": {
-            "1": {
-              "name": "variable.other.puppet"
-            },
-            "2": {
-              "name": "punctuation.definition.variable.puppet"
-            }
-          },
-          "match": "((\\$+)[a-zA-Z_][a-zA-Z0-9_]*)\\s*(?=,|\\))",
-          "name": "meta.function.argument.puppet"
-        },
-        {
-          "begin": "((\\$+)[a-zA-Z_][a-zA-Z0-9_]*)(?:\\s*(=)\\s*)\\s*",
-          "captures": {
-            "1": {
-              "name": "variable.other.puppet"
-            },
-            "2": {
-              "name": "punctuation.definition.variable.puppet"
-            },
-            "3": {
-              "name": "keyword.operator.assignment.puppet"
-            }
-          },
-          "end": "(?=,|\\))",
-          "name": "meta.function.argument.puppet",
-          "patterns": [
-            {
-              "include": "#parameter-default-types"
-            }
-          ]
+          "include": "#resource-parameters"
         },
         {
           "include": "#parameter-default-types"
@@ -143,59 +97,26 @@
       ]
     },
     {
-      "begin": "^\\s*(define|function)\\s+([a-zA-Z0-9_:]+)\\s*(\\()",
-      "beginCaptures": {
+      "begin": "^\\s*(define|function)\\s+((?#Bareword Resource Name)[a-z][a-z0-9_]*|(?#Qualified Resource Name)(?:[a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)+)\\s*(\\()",
+      "captures": {
         "1": {
           "name": "storage.type.function.puppet"
         },
         "2": {
           "name": "entity.name.function.puppet"
-        },
-        "3": {
-          "name": "punctuation.definition.parameters.begin.puppet"
         }
       },
-      "contentName": "meta.function.arguments.puppet",
-      "end": "\\)",
-      "endCaptures": {
-        "1": {
-          "name": "punctuation.definition.parameters.end.puppet"
-        }
-      },
+      "end": "(?={)",
       "name": "meta.function.puppet",
       "patterns": [
         {
-          "captures": {
-            "1": {
-              "name": "variable.other.puppet"
-            },
-            "2": {
-              "name": "punctuation.definition.variable.puppet"
-            }
-          },
-          "match": "((\\$+)[a-zA-Z_][a-zA-Z0-9_]*)\\s*(?=,|\\))",
-          "name": "meta.function.argument.no-default.puppet"
+          "include": "#line_comment"
         },
         {
-          "begin": "((\\$+)[a-zA-Z_][a-zA-Z0-9_]*)(?:\\s*(=)\\s*)\\s*",
-          "captures": {
-            "1": {
-              "name": "variable.other.puppet"
-            },
-            "2": {
-              "name": "punctuation.definition.variable.puppet"
-            },
-            "3": {
-              "name": "keyword.operator.assignment.puppet"
-            }
-          },
-          "end": "(?=,|\\))",
-          "name": "meta.function.argument.default.puppet",
-          "patterns": [
-            {
-              "include": "#parameter-default-types"
-            }
-          ]
+          "include": "#resource-parameters"
+        },
+        {
+          "include": "#parameter-default-types"
         }
       ]
     },
@@ -236,6 +157,7 @@
         }
       },
       "end": "(?=\\s|$)",
+      "contentName": "variable.parameter.include.puppet",
       "name": "meta.include.puppet"
     },
     {
@@ -560,6 +482,43 @@
         },
         {
           "include": "#puppet-datatypes"
+        }
+      ]
+    },
+    "resource-parameters": {
+      "patterns": [
+        {
+          "captures": {
+            "1": {
+              "name": "variable.other.puppet"
+            },
+            "2": {
+              "name": "punctuation.definition.variable.puppet"
+            }
+          },
+          "match": "((\\$+)[a-zA-Z_][a-zA-Z0-9_]*)\\s*(?=,|\\))",
+          "name": "meta.function.argument.puppet"
+        },
+        {
+          "begin": "((\\$+)[a-zA-Z_][a-zA-Z0-9_]*)(?:\\s*(=)\\s*)\\s*",
+          "captures": {
+            "1": {
+              "name": "variable.other.puppet"
+            },
+            "2": {
+              "name": "punctuation.definition.variable.puppet"
+            },
+            "3": {
+              "name": "keyword.operator.assignment.puppet"
+            }
+          },
+          "end": "(?=,|\\))",
+          "name": "meta.function.argument.puppet",
+          "patterns": [
+            {
+              "include": "#parameter-default-types"
+            }
+          ]
         }
       ]
     },

--- a/generated-syntaxes/puppet.tmLanguage.yaml
+++ b/generated-syntaxes/puppet.tmLanguage.yaml
@@ -10,7 +10,16 @@ patterns:
   - begin: ^\s*/\*
     end: \*/
     name: comment.block.puppet
-  - begin: '\b(node|class)\s+((?:[-_A-Za-z0-9"\''.]+::)*[-_A-Za-z0-9"\''.]+)\s*'
+  - begin: '\b(node)\s+(\"[^\"]+\"|\''[^\'']+\'')\s*'
+    captures:
+      '1':
+        name: storage.type.puppet
+      '2':
+        name: entity.name.type.class.puppet
+    end: '(?={)'
+    name: meta.definition.class.puppet
+    patterns: []
+  - begin: '\b(class)\s+((?#Qualified Resource Name)(?:[a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)+|(?#Bareword Resource Name)[a-z][a-z0-9_]*)\s*'
     captures:
       '1':
         name: storage.type.puppet
@@ -29,27 +38,9 @@ patterns:
           - match: '\b((?:[-_A-Za-z0-9".]+::)*[-_A-Za-z0-9".]+)\b'
             name: support.type.puppet
       - include: '#line_comment'
-      - captures:
-          '1':
-            name: variable.other.puppet
-          '2':
-            name: punctuation.definition.variable.puppet
-        match: '((\$+)[a-zA-Z_][a-zA-Z0-9_]*)\s*(?=,|\))'
-        name: meta.function.argument.puppet
-      - begin: '((\$+)[a-zA-Z_][a-zA-Z0-9_]*)(?:\s*(=)\s*)\s*'
-        captures:
-          '1':
-            name: variable.other.puppet
-          '2':
-            name: punctuation.definition.variable.puppet
-          '3':
-            name: keyword.operator.assignment.puppet
-        end: '(?=,|\))'
-        name: meta.function.argument.puppet
-        patterns:
-          - include: '#parameter-default-types'
+      - include: '#resource-parameters'
       - include: '#parameter-default-types'
-  - begin: '^\s*(plan)\s+((?:[a-z][a-z0-9_]+::)*[a-z][a-z0-9_]+)\s*'
+  - begin: '^\s*(plan)\s+((?#Qualified Resource Name)(?:[a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)+|(?#Bareword Resource Name)[a-z][a-z0-9_]*)\s*'
     captures:
       '1':
         name: storage.type.puppet
@@ -59,60 +50,20 @@ patterns:
     name: meta.definition.plan.puppet
     patterns:
       - include: '#line_comment'
-      - captures:
-          '1':
-            name: variable.other.puppet
-          '2':
-            name: punctuation.definition.variable.puppet
-        match: '((\$+)[a-zA-Z_][a-zA-Z0-9_]*)\s*(?=,|\))'
-        name: meta.function.argument.puppet
-      - begin: '((\$+)[a-zA-Z_][a-zA-Z0-9_]*)(?:\s*(=)\s*)\s*'
-        captures:
-          '1':
-            name: variable.other.puppet
-          '2':
-            name: punctuation.definition.variable.puppet
-          '3':
-            name: keyword.operator.assignment.puppet
-        end: '(?=,|\))'
-        name: meta.function.argument.puppet
-        patterns:
-          - include: '#parameter-default-types'
+      - include: '#resource-parameters'
       - include: '#parameter-default-types'
-  - begin: '^\s*(define|function)\s+([a-zA-Z0-9_:]+)\s*(\()'
-    beginCaptures:
+  - begin: '^\s*(define|function)\s+((?#Bareword Resource Name)[a-z][a-z0-9_]*|(?#Qualified Resource Name)(?:[a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)+)\s*(\()'
+    captures:
       '1':
         name: storage.type.function.puppet
       '2':
         name: entity.name.function.puppet
-      '3':
-        name: punctuation.definition.parameters.begin.puppet
-    contentName: meta.function.arguments.puppet
-    end: \)
-    endCaptures:
-      '1':
-        name: punctuation.definition.parameters.end.puppet
+    end: '(?={)'
     name: meta.function.puppet
     patterns:
-      - captures:
-          '1':
-            name: variable.other.puppet
-          '2':
-            name: punctuation.definition.variable.puppet
-        match: '((\$+)[a-zA-Z_][a-zA-Z0-9_]*)\s*(?=,|\))'
-        name: meta.function.argument.no-default.puppet
-      - begin: '((\$+)[a-zA-Z_][a-zA-Z0-9_]*)(?:\s*(=)\s*)\s*'
-        captures:
-          '1':
-            name: variable.other.puppet
-          '2':
-            name: punctuation.definition.variable.puppet
-          '3':
-            name: keyword.operator.assignment.puppet
-        end: '(?=,|\))'
-        name: meta.function.argument.default.puppet
-        patterns:
-          - include: '#parameter-default-types'
+      - include: '#line_comment'
+      - include: '#resource-parameters'
+      - include: '#parameter-default-types'
   - include: '#resource-definition'
   - match: '\b(case|if|else|elsif|unless)(?!::)\b'
     name: keyword.control.puppet
@@ -129,6 +80,7 @@ patterns:
       '1':
         name: keyword.control.import.include.puppet
     end: (?=\s|$)
+    contentName: variable.parameter.include.puppet
     name: meta.include.puppet
   - match: \b\w+\s*(?==>)\s*
     name: constant.other.key.puppet
@@ -301,6 +253,27 @@ repository:
       - include: '#function_call'
       - include: '#constants'
       - include: '#puppet-datatypes'
+  resource-parameters:
+    patterns:
+      - captures:
+          '1':
+            name: variable.other.puppet
+          '2':
+            name: punctuation.definition.variable.puppet
+        match: '((\$+)[a-zA-Z_][a-zA-Z0-9_]*)\s*(?=,|\))'
+        name: meta.function.argument.puppet
+      - begin: '((\$+)[a-zA-Z_][a-zA-Z0-9_]*)(?:\s*(=)\s*)\s*'
+        captures:
+          '1':
+            name: variable.other.puppet
+          '2':
+            name: punctuation.definition.variable.puppet
+          '3':
+            name: keyword.operator.assignment.puppet
+        end: '(?=,|\))'
+        name: meta.function.argument.puppet
+        patterns:
+          - include: '#parameter-default-types'
   array:
     begin: '(\[)'
     beginCaptures:

--- a/syntaxes/puppet.tmLanguage
+++ b/syntaxes/puppet.tmLanguage
@@ -374,6 +374,8 @@
       </dict>
       <key>end</key>
       <string>(?=\s|$)</string>
+      <key>contentName</key>
+      <string>variable.parameter.include.puppet</string>
       <key>name</key>
       <string>meta.include.puppet</string>
     </dict>

--- a/syntaxes/puppet.tmLanguage
+++ b/syntaxes/puppet.tmLanguage
@@ -232,8 +232,9 @@
     </dict>
     <dict>
       <key>begin</key>
-      <string>^\s*(define|function)\s+([a-zA-Z0-9_:]+)\s*(\()</string>
-      <key>beginCaptures</key>
+      <!-- Function and Defined Type names are specified as per https://puppet.com/docs/puppet/5.0/lang_reserved.html#classes-and-defined-resource-types -->
+      <string>^\s*(define|function)\s+((?#Bareword Resource Name)[a-z][a-z0-9_]*|(?#Qualified Resource Name)(?:[a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)+)\s*(\()</string>
+      <key>captures</key>
       <dict>
         <key>1</key>
         <dict>
@@ -245,28 +246,18 @@
           <key>name</key>
           <string>entity.name.function.puppet</string>
         </dict>
-        <key>3</key>
-        <dict>
-          <key>name</key>
-          <string>punctuation.definition.parameters.begin.puppet</string>
-        </dict>
       </dict>
-      <key>contentName</key>
-      <string>meta.function.arguments.puppet</string>
       <key>end</key>
-      <string>\)</string>
-      <key>endCaptures</key>
-      <dict>
-        <key>1</key>
-        <dict>
-          <key>name</key>
-          <string>punctuation.definition.parameters.end.puppet</string>
-        </dict>
-      </dict>
+      <string>(?={)</string>
       <key>name</key>
       <string>meta.function.puppet</string>
       <key>patterns</key>
       <array>
+        <dict>
+          <key>include</key>
+          <string>#line_comment</string>
+        </dict>
+        <!-- `$param,` -->
         <dict>
           <key>captures</key>
           <dict>
@@ -284,8 +275,9 @@
           <key>match</key>
           <string>((\$+)[a-zA-Z_][a-zA-Z0-9_]*)\s*(?=,|\))</string>
           <key>name</key>
-          <string>meta.function.argument.no-default.puppet</string>
+          <string>meta.function.argument.puppet</string>
         </dict>
+        <!-- `$param = ...,` -->
         <dict>
           <key>begin</key>
           <string>((\$+)[a-zA-Z_][a-zA-Z0-9_]*)(?:\s*(=)\s*)\s*</string>
@@ -310,7 +302,7 @@
           <key>end</key>
           <string>(?=,|\))</string>
           <key>name</key>
-          <string>meta.function.argument.default.puppet</string>
+          <string>meta.function.argument.puppet</string>
           <key>patterns</key>
           <array>
             <dict>
@@ -318,6 +310,10 @@
               <string>#parameter-default-types</string>
             </dict>
           </array>
+        </dict>
+        <dict>
+          <key>include</key>
+          <string>#parameter-default-types</string>
         </dict>
       </array>
     </dict>

--- a/syntaxes/puppet.tmLanguage
+++ b/syntaxes/puppet.tmLanguage
@@ -33,8 +33,33 @@
       <string>comment.block.puppet</string>
     </dict>
     <dict>
+      <!-- node names are basically open to anything https://puppet.com/docs/puppet/6.4/lang_reserved.html#nodes -->
       <key>begin</key>
-      <string>\b(node|class)\s+((?:[-_A-Za-z0-9"\'.]+::)*[-_A-Za-z0-9"\'.]+)\s*</string>
+      <string>\b(node)\s+(\"[^\"]+\"|\'[^\']+\')\s*</string>
+      <key>captures</key>
+      <dict>
+        <key>1</key>
+        <dict>
+          <key>name</key>
+          <string>storage.type.puppet</string>
+        </dict>
+        <key>2</key>
+        <dict>
+          <key>name</key>
+          <string>entity.name.type.class.puppet</string>
+        </dict>
+      </dict>
+      <key>end</key>
+      <string>(?={)</string>
+      <key>name</key>
+      <string>meta.definition.class.puppet</string>
+      <key>patterns</key>
+      <array />
+    </dict>
+    <dict>
+      <!-- Class names are specified as per https://puppet.com/docs/puppet/5.0/lang_reserved.html#classes-and-defined-resource-types -->
+      <key>begin</key>
+      <string>\b(class)\s+((?#Qualified Resource Name)(?:[a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)+|(?#Bareword Resource Name)[a-z][a-z0-9_]*)\s*</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -146,7 +171,7 @@
     <!-- Ref https://puppet.com/docs/bolt/0.x/writing_plans.html#naming-plans -->
     <dict>
       <key>begin</key>
-      <string>^\s*(plan)\s+((?:[a-z][a-z0-9_]+::)*[a-z][a-z0-9_]+)\s*</string>
+      <string>^\s*(plan)\s+((?#Qualified Resource Name)(?:[a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)+|(?#Bareword Resource Name)[a-z][a-z0-9_]*)\s*</string>
       <key>captures</key>
       <dict>
         <key>1</key>

--- a/syntaxes/puppet.tmLanguage
+++ b/syntaxes/puppet.tmLanguage
@@ -108,59 +108,9 @@
           <key>include</key>
           <string>#line_comment</string>
         </dict>
-        <!-- `$param,` -->
         <dict>
-          <key>captures</key>
-          <dict>
-            <key>1</key>
-            <dict>
-              <key>name</key>
-              <string>variable.other.puppet</string>
-            </dict>
-            <key>2</key>
-            <dict>
-              <key>name</key>
-              <string>punctuation.definition.variable.puppet</string>
-            </dict>
-          </dict>
-          <key>match</key>
-          <string>((\$+)[a-zA-Z_][a-zA-Z0-9_]*)\s*(?=,|\))</string>
-          <key>name</key>
-          <string>meta.function.argument.puppet</string>
-        </dict>
-        <!-- `$param = ...,` -->
-        <dict>
-          <key>begin</key>
-          <string>((\$+)[a-zA-Z_][a-zA-Z0-9_]*)(?:\s*(=)\s*)\s*</string>
-          <key>captures</key>
-          <dict>
-            <key>1</key>
-            <dict>
-              <key>name</key>
-              <string>variable.other.puppet</string>
-            </dict>
-            <key>2</key>
-            <dict>
-              <key>name</key>
-              <string>punctuation.definition.variable.puppet</string>
-            </dict>
-            <key>3</key>
-            <dict>
-              <key>name</key>
-              <string>keyword.operator.assignment.puppet</string>
-            </dict>
-          </dict>
-          <key>end</key>
-          <string>(?=,|\))</string>
-          <key>name</key>
-          <string>meta.function.argument.puppet</string>
-          <key>patterns</key>
-          <array>
-            <dict>
-              <key>include</key>
-              <string>#parameter-default-types</string>
-            </dict>
-          </array>
+          <key>include</key>
+          <string>#resource-parameters</string>
         </dict>
         <dict>
           <key>include</key>
@@ -195,59 +145,9 @@
           <key>include</key>
           <string>#line_comment</string>
         </dict>
-        <!-- `$param,` -->
         <dict>
-          <key>captures</key>
-          <dict>
-            <key>1</key>
-            <dict>
-              <key>name</key>
-              <string>variable.other.puppet</string>
-            </dict>
-            <key>2</key>
-            <dict>
-              <key>name</key>
-              <string>punctuation.definition.variable.puppet</string>
-            </dict>
-          </dict>
-          <key>match</key>
-          <string>((\$+)[a-zA-Z_][a-zA-Z0-9_]*)\s*(?=,|\))</string>
-          <key>name</key>
-          <string>meta.function.argument.puppet</string>
-        </dict>
-        <!-- `$param = ...,` -->
-        <dict>
-          <key>begin</key>
-          <string>((\$+)[a-zA-Z_][a-zA-Z0-9_]*)(?:\s*(=)\s*)\s*</string>
-          <key>captures</key>
-          <dict>
-            <key>1</key>
-            <dict>
-              <key>name</key>
-              <string>variable.other.puppet</string>
-            </dict>
-            <key>2</key>
-            <dict>
-              <key>name</key>
-              <string>punctuation.definition.variable.puppet</string>
-            </dict>
-            <key>3</key>
-            <dict>
-              <key>name</key>
-              <string>keyword.operator.assignment.puppet</string>
-            </dict>
-          </dict>
-          <key>end</key>
-          <string>(?=,|\))</string>
-          <key>name</key>
-          <string>meta.function.argument.puppet</string>
-          <key>patterns</key>
-          <array>
-            <dict>
-              <key>include</key>
-              <string>#parameter-default-types</string>
-            </dict>
-          </array>
+          <key>include</key>
+          <string>#resource-parameters</string>
         </dict>
         <dict>
           <key>include</key>
@@ -282,59 +182,9 @@
           <key>include</key>
           <string>#line_comment</string>
         </dict>
-        <!-- `$param,` -->
         <dict>
-          <key>captures</key>
-          <dict>
-            <key>1</key>
-            <dict>
-              <key>name</key>
-              <string>variable.other.puppet</string>
-            </dict>
-            <key>2</key>
-            <dict>
-              <key>name</key>
-              <string>punctuation.definition.variable.puppet</string>
-            </dict>
-          </dict>
-          <key>match</key>
-          <string>((\$+)[a-zA-Z_][a-zA-Z0-9_]*)\s*(?=,|\))</string>
-          <key>name</key>
-          <string>meta.function.argument.puppet</string>
-        </dict>
-        <!-- `$param = ...,` -->
-        <dict>
-          <key>begin</key>
-          <string>((\$+)[a-zA-Z_][a-zA-Z0-9_]*)(?:\s*(=)\s*)\s*</string>
-          <key>captures</key>
-          <dict>
-            <key>1</key>
-            <dict>
-              <key>name</key>
-              <string>variable.other.puppet</string>
-            </dict>
-            <key>2</key>
-            <dict>
-              <key>name</key>
-              <string>punctuation.definition.variable.puppet</string>
-            </dict>
-            <key>3</key>
-            <dict>
-              <key>name</key>
-              <string>keyword.operator.assignment.puppet</string>
-            </dict>
-          </dict>
-          <key>end</key>
-          <string>(?=,|\))</string>
-          <key>name</key>
-          <string>meta.function.argument.puppet</string>
-          <key>patterns</key>
-          <array>
-            <dict>
-              <key>include</key>
-              <string>#parameter-default-types</string>
-            </dict>
-          </array>
+          <key>include</key>
+          <string>#resource-parameters</string>
         </dict>
         <dict>
           <key>include</key>
@@ -903,7 +753,66 @@
         </dict>
       </array>
     </dict>
-
+    <key>resource-parameters</key>
+    <dict>
+      <key>patterns</key>
+      <array>
+        <!-- `$param,` -->
+        <dict>
+          <key>captures</key>
+          <dict>
+            <key>1</key>
+            <dict>
+              <key>name</key>
+              <string>variable.other.puppet</string>
+            </dict>
+            <key>2</key>
+            <dict>
+              <key>name</key>
+              <string>punctuation.definition.variable.puppet</string>
+            </dict>
+          </dict>
+          <key>match</key>
+          <string>((\$+)[a-zA-Z_][a-zA-Z0-9_]*)\s*(?=,|\))</string>
+          <key>name</key>
+          <string>meta.function.argument.puppet</string>
+        </dict>
+        <!-- `$param = ...,` -->
+        <dict>
+          <key>begin</key>
+          <string>((\$+)[a-zA-Z_][a-zA-Z0-9_]*)(?:\s*(=)\s*)\s*</string>
+          <key>captures</key>
+          <dict>
+            <key>1</key>
+            <dict>
+              <key>name</key>
+              <string>variable.other.puppet</string>
+            </dict>
+            <key>2</key>
+            <dict>
+              <key>name</key>
+              <string>punctuation.definition.variable.puppet</string>
+            </dict>
+            <key>3</key>
+            <dict>
+              <key>name</key>
+              <string>keyword.operator.assignment.puppet</string>
+            </dict>
+          </dict>
+          <key>end</key>
+          <string>(?=,|\))</string>
+          <key>name</key>
+          <string>meta.function.argument.puppet</string>
+          <key>patterns</key>
+          <array>
+            <dict>
+              <key>include</key>
+              <string>#parameter-default-types</string>
+            </dict>
+          </array>
+        </dict>
+      </array>
+    </dict>
     <key>array</key>
     <dict>
       <key>begin</key>

--- a/tests/syntaxes/puppet.tmLanguage.js
+++ b/tests/syntaxes/puppet.tmLanguage.js
@@ -270,15 +270,22 @@ describe('puppet.tmLanguage', function() {
       expect(tokens[8]).to.eql({value: 'myvar', scopes: ['source.puppet', 'meta.definition.class.puppet', 'meta.function.argument.puppet', 'variable.other.puppet']});
     });
 
-
-    it("tokenizes include as an include function", function() {
+    it("tokenizes contain as an include function", function() {
       var tokens = getLineTokens(grammar, "contain foo")
       expect(tokens[0]).to.eql({value: 'contain', scopes: ['source.puppet', 'meta.include.puppet', 'keyword.control.import.include.puppet']});
+      expect(tokens[2]).to.eql({value: 'foo', scopes: ['source.puppet', 'meta.include.puppet', 'variable.parameter.include.puppet']});
     });
 
-    it("tokenizes contain as an include function", function() {
+    it("tokenizes include as an include function", function() {
       var tokens = getLineTokens(grammar, 'include foo')
       expect(tokens[0]).to.eql({value: 'include', scopes: ['source.puppet', 'meta.include.puppet', 'keyword.control.import.include.puppet']});
+      expect(tokens[2]).to.eql({value: 'foo', scopes: ['source.puppet', 'meta.include.puppet', 'variable.parameter.include.puppet']});
+    });
+
+    it("tokenizes import as an include function", function() {
+      var tokens = getLineTokens(grammar, 'import foo')
+      expect(tokens[0]).to.eql({value: 'import', scopes: ['source.puppet', 'meta.include.puppet', 'keyword.control.import.include.puppet']});
+      expect(tokens[2]).to.eql({value: 'foo', scopes: ['source.puppet', 'meta.include.puppet', 'variable.parameter.include.puppet']});
     });
 
     it("tokenizes resource type and string title", function() {
@@ -298,6 +305,7 @@ describe('puppet.tmLanguage', function() {
     it("tokenizes require classname as an include", function() {
       var tokens = getLineTokens(grammar, "require ::foo")
       expect(tokens[0]).to.eql({value: 'require', scopes: ['source.puppet', 'meta.include.puppet', 'keyword.control.import.include.puppet']});
+      expect(tokens[2]).to.eql({value: '::foo', scopes: ['source.puppet', 'meta.include.puppet', 'variable.parameter.include.puppet']});
     });
 
     it("tokenizes require => variable as a parameter", function() {


### PR DESCRIPTION
Builds on #36
Fixes #38
Fixes #39

---

Previously the class name for the include statements was not tagged as a
parameter, much like a function call. This commit modifies the tokenising to
tag the class being included as a variable.parameter.include.puppet.

---

Previously function parameters were not being tokenised correctly as per the
newer Puppet 4 API Data types.

This commit updates the function and defined type parameters to be similar to
that of classes and plans, whereby Puppet Data types etc. are tokenised
correctly.  This commit also adds tests for this scenario, and adds negative
tests to ensure that invalid names are not tokenised.

---

Previously the node, plan and class names were far too loose in what
characters were allowed:

* Plans and classes should only allow qualified names, with or without name
  segments.  Previously they allowed quotes, hyphens and capital letters
* Nodes can only accept strings for their names, with any characters, and have
  no parameters.  Previously nodes shared the class definition which is very
  different.

This commit moves the node detection to it's own section and tightens up the
allowed names for classes and plans.  This commit also adds tests for allowed
and disallowed names for plans, classes and nodes.

---

Reminder

- [x] Added Tests

- [x] Ran `npm run convert` and committed the changes too
