### PR TITLE
(GH-43) Fix syntax highlighting for resource references and chain arrows

### DIFF
--- a/generated-syntaxes/puppet.tmLanguage.atom.cson
+++ b/generated-syntaxes/puppet.tmLanguage.atom.cson
@@ -529,7 +529,7 @@
       }
     ]
   'resource-definition':
-    'begin': '^\\s*((?#Bareword Resource Name)[a-z][a-z0-9_]*|(?#Qualified Resource Name)(?:[a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)+)\\s*({)\\s*'
+    'begin': '(?:^\\s*|\\s+)((?#Bareword Resource Name)[a-z][a-z0-9_]*|(?#Qualified Resource Name)(?:[a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)+)\\s*({)\\s*'
     'beginCaptures':
       '1':
         'name': 'meta.definition.resource.puppet storage.type.puppet'
@@ -587,7 +587,7 @@
     'patterns': [
       {
         'comment': 'Puppet Data type'
-        'match': '(?<![a-zA-Z\\$])([A-Z][a-zA-Z0-9]*)(?![a-zA-Z0-9])'
+        'match': '(?<![a-zA-Z\\$])([A-Z][a-zA-Z0-9_]*)(?![a-zA-Z0-9_])'
         'name': 'storage.type.puppet'
       }
     ]

--- a/generated-syntaxes/puppet.tmLanguage.cson
+++ b/generated-syntaxes/puppet.tmLanguage.cson
@@ -528,7 +528,7 @@ repository:
       }
     ]
   "resource-definition":
-    begin: "^\\s*((?#Bareword Resource Name)[a-z][a-z0-9_]*|(?#Qualified Resource Name)(?:[a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)+)\\s*({)\\s*"
+    begin: "(?:^\\s*|\\s+)((?#Bareword Resource Name)[a-z][a-z0-9_]*|(?#Qualified Resource Name)(?:[a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)+)\\s*({)\\s*"
     beginCaptures:
       "1":
         name: "meta.definition.resource.puppet storage.type.puppet"
@@ -586,7 +586,7 @@ repository:
     patterns: [
       {
         comment: "Puppet Data type"
-        match: "(?<![a-zA-Z\\$])([A-Z][a-zA-Z0-9]*)(?![a-zA-Z0-9])"
+        match: "(?<![a-zA-Z\\$])([A-Z][a-zA-Z0-9_]*)(?![a-zA-Z0-9_])"
         name: "storage.type.puppet"
       }
     ]

--- a/generated-syntaxes/puppet.tmLanguage.json
+++ b/generated-syntaxes/puppet.tmLanguage.json
@@ -622,7 +622,7 @@
       ]
     },
     "resource-definition": {
-      "begin": "^\\s*((?#Bareword Resource Name)[a-z][a-z0-9_]*|(?#Qualified Resource Name)(?:[a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)+)\\s*({)\\s*",
+      "begin": "(?:^\\s*|\\s+)((?#Bareword Resource Name)[a-z][a-z0-9_]*|(?#Qualified Resource Name)(?:[a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)+)\\s*({)\\s*",
       "beginCaptures": {
         "1": {
           "name": "meta.definition.resource.puppet storage.type.puppet"
@@ -691,7 +691,7 @@
       "patterns": [
         {
           "comment": "Puppet Data type",
-          "match": "(?<![a-zA-Z\\$])([A-Z][a-zA-Z0-9]*)(?![a-zA-Z0-9])",
+          "match": "(?<![a-zA-Z\\$])([A-Z][a-zA-Z0-9_]*)(?![a-zA-Z0-9_])",
           "name": "storage.type.puppet"
         }
       ]

--- a/generated-syntaxes/puppet.tmLanguage.yaml
+++ b/generated-syntaxes/puppet.tmLanguage.yaml
@@ -330,7 +330,7 @@ repository:
         match: '(?<!\w)([-+]?)\d+\.\d+(?i:e(\+|-){0,1}\d+){0,1}(?!\w|\d)'
         name: constant.numeric.integer.puppet
   resource-definition:
-    begin: '^\s*((?#Bareword Resource Name)[a-z][a-z0-9_]*|(?#Qualified Resource Name)(?:[a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)+)\s*({)\s*'
+    begin: '(?:^\s*|\s+)((?#Bareword Resource Name)[a-z][a-z0-9_]*|(?#Qualified Resource Name)(?:[a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)+)\s*({)\s*'
     beginCaptures:
       '1':
         name: meta.definition.resource.puppet storage.type.puppet
@@ -368,7 +368,7 @@ repository:
   puppet-datatypes:
     patterns:
       - comment: Puppet Data type
-        match: '(?<![a-zA-Z\$])([A-Z][a-zA-Z0-9]*)(?![a-zA-Z0-9])'
+        match: '(?<![a-zA-Z\$])([A-Z][a-zA-Z0-9_]*)(?![a-zA-Z0-9_])'
         name: storage.type.puppet
   regex-literal:
     match: '(\/)(.+?)(?:[^\\]\/)'

--- a/syntaxes/puppet.tmLanguage
+++ b/syntaxes/puppet.tmLanguage
@@ -971,12 +971,12 @@
         </dict>
       </array>
     </dict>
-    <!-- Resource definition using a bareword of qualified resource name -->
+    <!-- Resource definition using a bareword or qualified resource name -->
     <!-- Reference https://puppet.com/docs/puppet/latest/lang_reserved.html#classes-and-defined-resource-types -->
     <key>resource-definition</key>
     <dict>
       <key>begin</key>
-      <string>^\s*((?#Bareword Resource Name)[a-z][a-z0-9_]*|(?#Qualified Resource Name)(?:[a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)+)\s*({)\s*</string>
+      <string>(?:^\s*|\s+)((?#Bareword Resource Name)[a-z][a-z0-9_]*|(?#Qualified Resource Name)(?:[a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)+)\s*({)\s*</string>
       <key>beginCaptures</key>
       <dict>
         <key>1</key>
@@ -1081,7 +1081,12 @@
         </dict>
       </array>
     </dict>
-    <!-- Ref: https://github.com/puppetlabs/puppet-specifications/blob/master/language/types_values_variables.md#the-type-system -->
+    <!--
+      Ref: https://github.com/puppetlabs/puppet-specifications/blob/master/language/types_values_variables.md#the-type-system
+
+      Resource References using a bareword or qualified resource name, but with captialised first segment letter, followed by opening square bracket, but that can
+      have underscores as well. Resource References are technically a Puppet Data Type, so use the same tags
+      Ref: https://puppet.com/docs/puppet/latest/lang_data_resource_reference.html -->
     <key>puppet-datatypes</key>
     <dict>
       <key>patterns</key>
@@ -1090,7 +1095,7 @@
           <key>comment</key>
           <string>Puppet Data type</string>
           <key>match</key>
-          <string>(?&lt;![a-zA-Z\$])([A-Z][a-zA-Z0-9]*)(?![a-zA-Z0-9])</string>
+          <string>(?&lt;![a-zA-Z\$])([A-Z][a-zA-Z0-9_]*)(?![a-zA-Z0-9_])</string>
           <key>name</key>
           <string>storage.type.puppet</string>
         </dict>


### PR DESCRIPTION
Fixes #43

Previously the sytnax highlighting for resource references did not work for
valid names.  Although Puppet Types do not allow an underscore, Resource
References, which are technically types, do.  This commit changes the regex to
allow underscores as there's no way for the parser to know what kind of
reference it actually is

Previously the highlighting of class names after a chain arrow was failing. This
was due to the chain arrow not absorbing the whitespace after it.  This commit
changes the chain arrow regex to consume trailing and leading whitespace.

This commit also adds tests for these scenarios.

---

Reminder

- [x] Added Tests

- [x] Ran `npm run convert` and committed the changes too
