### PR TITLE
(GH-34) Comments in hashes should tokenize

### DIFF
--- a/generated-syntaxes/puppet.tmLanguage.atom.cson
+++ b/generated-syntaxes/puppet.tmLanguage.atom.cson
@@ -485,6 +485,9 @@
       {
         'include': '#parameter-default-types'
       }
+      {
+        'include': '#line_comment'
+      }
     ]
   'single-quoted-string':
     'begin': '\''

--- a/generated-syntaxes/puppet.tmLanguage.cson
+++ b/generated-syntaxes/puppet.tmLanguage.cson
@@ -484,6 +484,9 @@ repository:
       {
         include: "#parameter-default-types"
       }
+      {
+        include: "#line_comment"
+      }
     ]
   "single-quoted-string":
     begin: "'"

--- a/generated-syntaxes/puppet.tmLanguage.json
+++ b/generated-syntaxes/puppet.tmLanguage.json
@@ -569,6 +569,9 @@
         },
         {
           "include": "#parameter-default-types"
+        },
+        {
+          "include": "#line_comment"
         }
       ]
     },

--- a/generated-syntaxes/puppet.tmLanguage.yaml
+++ b/generated-syntaxes/puppet.tmLanguage.yaml
@@ -302,6 +302,7 @@ repository:
       - match: \b\w+\s*(?==>)\s*
         name: constant.other.key.puppet
       - include: '#parameter-default-types'
+      - include: '#line_comment'
   single-quoted-string:
     begin: ''''
     beginCaptures:

--- a/syntaxes/puppet.tmLanguage
+++ b/syntaxes/puppet.tmLanguage
@@ -889,6 +889,10 @@
           <key>include</key>
           <string>#parameter-default-types</string>
         </dict>
+        <dict>
+          <key>include</key>
+          <string>#line_comment</string>
+        </dict>
       </array>
     </dict>
     <key>single-quoted-string</key>

--- a/tests/syntaxes/puppet.tmLanguage.js
+++ b/tests/syntaxes/puppet.tmLanguage.js
@@ -118,6 +118,17 @@ describe('puppet.tmLanguage', function() {
     };
   });
 
+  describe('hashes', function() {
+    it("tokenizes line comments", function() {
+      var tokens = getLineTokens(grammar, "$x4 = [{ key1 => 'value',\n# comment\n}]")
+
+      token_prefix = [ 'source.puppet', 'meta.array.puppet', 'meta.hash.puppet', 'meta.comment.full-line.puppet', 'comment.line.number-sign.puppet' ]
+
+      expect(tokens[12]).to.eql({value: '#', scopes: token_prefix.concat(['punctuation.definition.comment.puppet'])});
+      expect(tokens[13]).to.eql({value: ' comment\n', scopes: token_prefix});
+    });
+  });
+
   describe('arrays', function() {
     it("tokenizes line comments", function() {
       var tokens = getLineTokens(grammar, "package{ [\n'element1', # This is a comment\n'element2']:\nensure => present\n}")


### PR DESCRIPTION
Fixes #34 

Previously, tokens within a hash, within an array would not tokenize correctly.
This commit adds the line comment type as a pattern for content within a hash.

---

Reminder

- [x] Added Tests

- [x] Ran `npm run convert` and committed the changes too
