### PR TITLE
(GH-46) Prepare for version 1.3.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## Unreleased
 
+## [1.3.3] - 2019-08-26
+
+### Fixed
+- ([GH-43](https://github.com/lingua-pupuli/puppet-editor-syntax/issues/43)) Fix syntax highlighting for resource references and chain arrows
+- ([GH-34](https://github.com/lingua-pupuli/puppet-editor-syntax/issues/34)) Comments in hashes should tokenize
+
 ## [1.3.2] - 2019-05-31
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-editor-syntax",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Fixes #46 

This commit prepares the project for a 1.3.3 release.