### PR TITLE
(GH-48) Correctly tokenise if-else

### DIFF
--- a/generated-syntaxes/puppet.tmLanguage.atom.cson
+++ b/generated-syntaxes/puppet.tmLanguage.atom.cson
@@ -107,11 +107,13 @@
     ]
   }
   {
-    'include': '#resource-definition'
+    'match': '\\b(case|else|elsif|if|unless)(?!::)\\b'
+    'captures':
+      '1':
+        'name': 'keyword.control.puppet'
   }
   {
-    'match': '\\b(case|if|else|elsif|unless)(?!::)\\b'
-    'name': 'keyword.control.puppet'
+    'include': '#resource-definition'
   }
   {
     'include': '#heredoc'
@@ -532,7 +534,7 @@
       }
     ]
   'resource-definition':
-    'begin': '(?:^\\s*|\\s+)((?#Bareword Resource Name)[a-z][a-z0-9_]*|(?#Qualified Resource Name)(?:[a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)+)\\s*({)\\s*'
+    'begin': '(?:^|\\b)((?#Toplevel Bareword)::[a-z][a-z0-9_]*|(?#Bareword Resource Name)[a-z][a-z0-9_]*|(?#Qualified Resource Name)(?:[a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)+)\\s*({)\\s*'
     'beginCaptures':
       '1':
         'name': 'meta.definition.resource.puppet storage.type.puppet'

--- a/generated-syntaxes/puppet.tmLanguage.cson
+++ b/generated-syntaxes/puppet.tmLanguage.cson
@@ -106,11 +106,13 @@ patterns: [
     ]
   }
   {
-    include: "#resource-definition"
+    match: "\\b(case|else|elsif|if|unless)(?!::)\\b"
+    captures:
+      "1":
+        name: "keyword.control.puppet"
   }
   {
-    match: "\\b(case|if|else|elsif|unless)(?!::)\\b"
-    name: "keyword.control.puppet"
+    include: "#resource-definition"
   }
   {
     include: "#heredoc"
@@ -531,7 +533,7 @@ repository:
       }
     ]
   "resource-definition":
-    begin: "(?:^\\s*|\\s+)((?#Bareword Resource Name)[a-z][a-z0-9_]*|(?#Qualified Resource Name)(?:[a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)+)\\s*({)\\s*"
+    begin: "(?:^|\\b)((?#Toplevel Bareword)::[a-z][a-z0-9_]*|(?#Bareword Resource Name)[a-z][a-z0-9_]*|(?#Qualified Resource Name)(?:[a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)+)\\s*({)\\s*"
     beginCaptures:
       "1":
         name: "meta.definition.resource.puppet storage.type.puppet"

--- a/generated-syntaxes/puppet.tmLanguage.json
+++ b/generated-syntaxes/puppet.tmLanguage.json
@@ -121,11 +121,15 @@
       ]
     },
     {
-      "include": "#resource-definition"
+      "match": "\\b(case|else|elsif|if|unless)(?!::)\\b",
+      "captures": {
+        "1": {
+          "name": "keyword.control.puppet"
+        }
+      }
     },
     {
-      "match": "\\b(case|if|else|elsif|unless)(?!::)\\b",
-      "name": "keyword.control.puppet"
+      "include": "#resource-definition"
     },
     {
       "include": "#heredoc"
@@ -625,7 +629,7 @@
       ]
     },
     "resource-definition": {
-      "begin": "(?:^\\s*|\\s+)((?#Bareword Resource Name)[a-z][a-z0-9_]*|(?#Qualified Resource Name)(?:[a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)+)\\s*({)\\s*",
+      "begin": "(?:^|\\b)((?#Toplevel Bareword)::[a-z][a-z0-9_]*|(?#Bareword Resource Name)[a-z][a-z0-9_]*|(?#Qualified Resource Name)(?:[a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)+)\\s*({)\\s*",
       "beginCaptures": {
         "1": {
           "name": "meta.definition.resource.puppet storage.type.puppet"

--- a/generated-syntaxes/puppet.tmLanguage.yaml
+++ b/generated-syntaxes/puppet.tmLanguage.yaml
@@ -64,9 +64,11 @@ patterns:
       - include: '#line_comment'
       - include: '#resource-parameters'
       - include: '#parameter-default-types'
+  - match: '\b(case|else|elsif|if|unless)(?!::)\b'
+    captures:
+      '1':
+        name: keyword.control.puppet
   - include: '#resource-definition'
-  - match: '\b(case|if|else|elsif|unless)(?!::)\b'
-    name: keyword.control.puppet
   - include: '#heredoc'
   - include: '#strings'
   - include: '#puppet-datatypes'
@@ -331,7 +333,7 @@ repository:
         match: '(?<!\w)([-+]?)\d+\.\d+(?i:e(\+|-){0,1}\d+){0,1}(?!\w|\d)'
         name: constant.numeric.integer.puppet
   resource-definition:
-    begin: '(?:^\s*|\s+)((?#Bareword Resource Name)[a-z][a-z0-9_]*|(?#Qualified Resource Name)(?:[a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)+)\s*({)\s*'
+    begin: '(?:^|\b)((?#Toplevel Bareword)::[a-z][a-z0-9_]*|(?#Bareword Resource Name)[a-z][a-z0-9_]*|(?#Qualified Resource Name)(?:[a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)+)\s*({)\s*'
     beginCaptures:
       '1':
         name: meta.definition.resource.puppet storage.type.puppet

--- a/syntaxes/puppet.tmLanguage
+++ b/syntaxes/puppet.tmLanguage
@@ -193,14 +193,20 @@
       </array>
     </dict>
     <dict>
-      <key>include</key>
-      <string>#resource-definition</string>
+      <key>match</key>
+      <string>\b(case|else|elsif|if|unless)(?!::)\b</string>
+      <key>captures</key>
+      <dict>
+        <key>1</key>
+        <dict>
+          <key>name</key>
+          <string>keyword.control.puppet</string>
+        </dict>
+      </dict>
     </dict>
     <dict>
-      <key>match</key>
-      <string>\b(case|if|else|elsif|unless)(?!::)\b</string>
-      <key>name</key>
-      <string>keyword.control.puppet</string>
+      <key>include</key>
+      <string>#resource-definition</string>
     </dict>
     <dict>
       <key>include</key>
@@ -980,7 +986,7 @@
     <key>resource-definition</key>
     <dict>
       <key>begin</key>
-      <string>(?:^\s*|\s+)((?#Bareword Resource Name)[a-z][a-z0-9_]*|(?#Qualified Resource Name)(?:[a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)+)\s*({)\s*</string>
+      <string>(?:^|\b)((?#Toplevel Bareword)::[a-z][a-z0-9_]*|(?#Bareword Resource Name)[a-z][a-z0-9_]*|(?#Qualified Resource Name)(?:[a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)+)\s*({)\s*</string>
       <key>beginCaptures</key>
       <dict>
         <key>1</key>

--- a/tests/syntaxes/puppet.tmLanguage.js
+++ b/tests/syntaxes/puppet.tmLanguage.js
@@ -370,6 +370,27 @@ describe('puppet.tmLanguage', function() {
       var tokens = getLineTokens(grammar, "package {'foo':}")
       expect(tokens[0]).to.eql({value: 'package', scopes: ['source.puppet', 'meta.definition.resource.puppet', 'storage.type.puppet']});
     });
+
+    describe('if else statements', function() {
+      var contexts = {
+        'spaced correctly': { 'expectedElseTokenIndex': 12, 'manifest': "if $foo {\n  $bar = '1'\n} else {\n  $bar = '2'\n}" },
+        'on same line':     { 'expectedElseTokenIndex': 12, 'manifest': "if $foo { $bar = '1' } else {  $bar = '2' }" },
+        'no spaces':        { 'expectedElseTokenIndex': 12, 'manifest': "if $foo {\n  $bar = '1'\n}else{\n  $bar = '2'\n}" },
+      }
+
+      for(var contextName in contexts) {
+        context(contextName, function() {
+          var manifest = contexts[contextName]['manifest']
+          var elseTokenIndex = contexts[contextName]['expectedElseTokenIndex']
+
+          it("tokenizes when " + contextName, function () {
+            var tokens = getLineTokens(grammar, manifest);
+            expect(tokens[0]).to.eql({value: 'if', scopes: ['source.puppet', 'keyword.control.puppet']});
+            expect(tokens[elseTokenIndex]).to.eql({ value: 'else', scopes: ['source.puppet', 'keyword.control.puppet'] });
+          });
+        });
+      };
+    });
   });
 
   describe('chaining arrows', function() {


### PR DESCRIPTION
Fixes #48

Previously in commit 0cda34ecf Resource Definitions was updated however it over
zealously was matched for `else {`.  It appears that \s style matchers are
preferred over \b. This commit:

* Moves resource definitions further down the match list so that if/else
  constructs are evaluated first.
* Updates the the resource-definition regex to use \b instead of \s. This also
  caused the top-level bareword section to be added as the double colon was
  causing the resource name matching to end prematurely.
* Adds some basic tests for if-else matching.

Thanks @nvergottini for the bug report.

---

Reminder

- [x] Added Tests

- [x] Ran `npm run convert` and committed the changes too
