### PR TITLE
(GH-50) Prepare for version 1.3.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## Unreleased
 
+## [1.3.4] - 2019-09-20
+
+### Fixed
+- ([GH-48](https://github.com/lingua-pupuli/puppet-editor-syntax/issues/48)) Correctly tokenise if-else
+
 ## [1.3.3] - 2019-08-26
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-editor-syntax",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Fixes #50 

This commit prepares the project for a 1.3.4 release.

---

Reminder

- [x] Added Tests

- [x] Ran `npm run convert` and committed the changes too
