### PR TITLE
(GH-52) Allow upppercase letters in variable names

### DIFF
--- a/generated-syntaxes/puppet.tmLanguage.atom.cson
+++ b/generated-syntaxes/puppet.tmLanguage.atom.cson
@@ -568,7 +568,7 @@
             'name': 'punctuation.definition.variable.puppet'
       }
       {
-        'match': '(\\$)(([a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)*)'
+        'match': '(\\$)(([a-z][a-zA-Z0-9_]*)?(?:::[a-z][a-zA-Z0-9_]*)*)'
         'name': 'variable.other.readwrite.global.puppet'
         'captures':
           '1':

--- a/generated-syntaxes/puppet.tmLanguage.cson
+++ b/generated-syntaxes/puppet.tmLanguage.cson
@@ -567,7 +567,7 @@ repository:
             name: "punctuation.definition.variable.puppet"
       }
       {
-        match: "(\\$)(([a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)*)"
+        match: "(\\$)(([a-z][a-zA-Z0-9_]*)?(?:::[a-z][a-zA-Z0-9_]*)*)"
         name: "variable.other.readwrite.global.puppet"
         captures:
           "1":

--- a/generated-syntaxes/puppet.tmLanguage.json
+++ b/generated-syntaxes/puppet.tmLanguage.json
@@ -670,7 +670,7 @@
           }
         },
         {
-          "match": "(\\$)(([a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)*)",
+          "match": "(\\$)(([a-z][a-zA-Z0-9_]*)?(?:::[a-z][a-zA-Z0-9_]*)*)",
           "name": "variable.other.readwrite.global.puppet",
           "captures": {
             "1": {

--- a/generated-syntaxes/puppet.tmLanguage.yaml
+++ b/generated-syntaxes/puppet.tmLanguage.yaml
@@ -355,7 +355,7 @@ repository:
         captures:
           '1':
             name: punctuation.definition.variable.puppet
-      - match: '(\$)(([a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)*)'
+      - match: '(\$)(([a-z][a-zA-Z0-9_]*)?(?:::[a-z][a-zA-Z0-9_]*)*)'
         name: variable.other.readwrite.global.puppet
         captures:
           '1':

--- a/syntaxes/puppet.tmLanguage
+++ b/syntaxes/puppet.tmLanguage
@@ -1055,7 +1055,7 @@
         <!-- Qualified variable names (Can't start with underscore) -->
         <dict>
           <key>match</key>
-          <string>(\$)(([a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)*)</string>
+          <string>(\$)(([a-z][a-zA-Z0-9_]*)?(?:::[a-z][a-zA-Z0-9_]*)*)</string>
           <key>name</key>
           <string>variable.other.readwrite.global.puppet</string>
           <key>captures</key>

--- a/tests/syntaxes/puppet.tmLanguage.js
+++ b/tests/syntaxes/puppet.tmLanguage.js
@@ -469,6 +469,7 @@ describe('puppet.tmLanguage', function() {
     // Straight up variable names
     var contexts = {
       'a bare variable name'               : { 'testcase': "myvar123_456" },
+      'a bare camelcase variable name'     : { 'testcase': "myVariableName" },
       'a top level variable name'          : { 'testcase': "::my23_456abc" },
       'a qualified variable name'          : { 'testcase': "myscope::myvar123_456" },
       'a top level qualified variable name': { 'testcase': "::myscope::myvar123_456" },


### PR DESCRIPTION
Fixes #52

Previously only lower case letters where allowed in qualified variable names.
This commit updates the pattern for variable names, and adds a test for
camel-cased variable names.

---

Reminder

- [x] Added Tests

- [x] Ran `npm run convert` and committed the changes too
